### PR TITLE
Titanic dataset: mark genders and embarkation_ports as enumerations

### DIFF
--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -56,6 +56,7 @@
     {
       "@type": "ml:RecordSet",
       "name": "genders",
+      "ml:isEnumeration": true,
       "description": "Maps gender labels to semantic definitions.",
       "key": "#{label}",
       "field": [
@@ -84,6 +85,7 @@
     {
       "@type": "ml:RecordSet",
       "name": "embarkation_ports",
+      "ml:isEnumeration": true,
       "description": "Maps Embarkation port initial to labeled values.",
       "key": "#{key}",
       "field": [


### PR DESCRIPTION
This is following https://github.com/mlcommons/croissant/discussions/52.

I'll use that to create a documentation page for enumeration, which I then need for a documentation page on labels.