### PR TITLE
coco2014: mark categories RecordSet and supercategory field as Enumeration.

### DIFF
--- a/datasets/coco2014/metadata.json
+++ b/datasets/coco2014/metadata.json
@@ -236,7 +236,7 @@
     {
       "name": "categories",
       "@type": "ml:RecordSet",
-      "ml:isEnumeration": "true",
+      "ml:isEnumeration": true,
       "key": "#{id}",
       "field": [
         {
@@ -259,7 +259,7 @@
         {
           "name": "supercategory",
           "@type": "ml:Field",
-          "ml:isEnumeration": "true",
+          "ml:isEnumeration": true,
           "description": "The name of the supercategory.",
           "dataType": [
             "sc:Text",

--- a/datasets/coco2014/metadata.json
+++ b/datasets/coco2014/metadata.json
@@ -236,6 +236,7 @@
     {
       "name": "categories",
       "@type": "ml:RecordSet",
+      "ml:isEnumeration": "true",
       "key": "#{id}",
       "field": [
         {
@@ -258,6 +259,7 @@
         {
           "name": "supercategory",
           "@type": "ml:Field",
+          "ml:isEnumeration": "true",
           "description": "The name of the supercategory.",
           "dataType": [
             "sc:Text",

--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -56,6 +56,7 @@
     {
       "@type": "ml:RecordSet",
       "name": "genders",
+      "ml:isEnumeration": true,
       "description": "Maps gender labels to semantic definitions.",
       "key": "#{label}",
       "field": [
@@ -84,6 +85,7 @@
     {
       "@type": "ml:RecordSet",
       "name": "embarkation_ports",
+      "ml:isEnumeration": true,
       "description": "Maps Embarkation port initial to labeled values.",
       "key": "#{key}",
       "field": [


### PR DESCRIPTION
Again, following https://github.com/mlcommons/croissant/discussions/52.

The `ml:isEnum` is set on the supercategory field, since there are no RecordSet defined for those.

There is some ambiguity here though: which of `name` and `supercategory` is the most numerous?
We don't know, and unless we read the data, with no extra indication of cardinality, there could also be the same cardinality for the two fields.

One possibility: establish the rule that when `"ml:isEnumeration": true` is set on a `RecordSet`, then if that `RecordSet` has a Field with `"ml:isEnumeration": true`, the cardinality of that field must be smaller than the cardinality of the `RecordSet`.  That describes well the use case of categories and super-categories like in coco2014, but I don't know if there are other datasets where this wouldn't hold. If no objections with that, we can go with that rule until we find a counter-example.