### PR TITLE
Add back movielens and wiki-text to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,8 @@ jobs:
       run: pip install .
 
     - name: Validate JSON-LD files
-      # wiki-text is excluded at the moment. See: https://github.com/mlcommons/croissant/issues/101.
       run: |
-        JSON_FILES=$(find ../../datasets/ -type f -name "*.json" ! -path '*wiki-text*')
+        JSON_FILES=$(find ../../datasets/ -type f -name "*.json")
         for file in ${JSON_FILES}
         do
           echo "Validating ${file}..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,8 @@ jobs:
 
     - name: Validate JSON-LD files
       # wiki-text is excluded at the moment. See: https://github.com/mlcommons/croissant/issues/101.
-      # movielens is excluded at the moment. See: https://github.com/mlcommons/croissant/issues/103.
       run: |
-        JSON_FILES=$(find ../../datasets/ -type f -name "*.json" ! -path '*wiki-text*' ! -path '*movielens*')
+        JSON_FILES=$(find ../../datasets/ -type f -name "*.json" ! -path '*wiki-text*')
         for file in ${JSON_FILES}
         do
           echo "Validating ${file}..."

--- a/datasets/movielens/metadata.json
+++ b/datasets/movielens/metadata.json
@@ -201,7 +201,7 @@
         {
           "name": "movie_genres",
           "@type": "ml:Field",
-          "source": "#{movies/genres}"
+          "source": "#{movies/genre}"
         },
         {
           "name": "ratings",

--- a/python/ml_croissant/README.md
+++ b/python/ml_croissant/README.md
@@ -40,12 +40,12 @@ pytest .
 The most important modules in the library are:
 
 - [`ml_croissant/_src/structure_graph`](./ml_croissant/_src/structure_graph/graph.py) is responsible for the **static analysis** of the Croissant files. We convert Croissant files to a Python representation called "**structure graph**" (using [NetworkX](https://networkx.org/)). In the process, we catch any static analysis issues (e.g., a missing mandatory field or a logic problem in the file).
-- [`ml_croissant/_src/operation_graph`](./ml_croissant/_src/operation_graph/graph.py) is responsible for the **dynamic analysis** of the Croissant files (i.e., actually loading the dataset by yielding examples). We convert the structure graph into an "**operation graph**". Operations are the unit transformation that allow to build the dataset (like [`Download`](./ml_croissant/_src/operation_graph/operations/download.py), [`Extract`](./ml_croissant/_src/operation_graph/operations/extract.py), etc).
+- [`ml_croissant/_src/operation_graph`](./ml_croissant/_src/operation_graph/graph.py) is responsible for the **dynamic analysis** of the Croissant files (i.e., actually loading the dataset by yielding examples). We convert the structure graph into an "**operation graph**". Operations are the unit transformations that allow to build the dataset (like [`Download`](./ml_croissant/_src/operation_graph/operations/download.py), [`Extract`](./ml_croissant/_src/operation_graph/operations/extract.py), etc).
 
 Other important modules are:
 
 - [`ml_croissant/_src/core`](./ml_croissant/_src/core) defines all needed core internals. For instance, [`Issues`](./ml_croissant/_src/core/issues.py) are a way to track errors and warning during the analysis of Croissant files.
-- [`ml_croissant/__init__`](./ml_croissant/__init__.py) declares the public API with [`ml_croissant.Dataset`](./ml_croissant/_src/datasets.py).
+- [`ml_croissant/__init__.py`](./ml_croissant/__init__.py) declares the public API with [`ml_croissant.Dataset`](./ml_croissant/_src/datasets.py).
 
 For the full design, refer to the [design doc](https://docs.google.com/document/d/1zYQIUX9ae1sZOOBq9OCsJ8JW8-Ejy3NLSeqaI5LtOEM/edit?resourcekey=0-CK78DfFvF7fnufyZqF3h3Q) for an overview of the implementation.
 

--- a/python/ml_croissant/ml_croissant/_src/core/constants.py
+++ b/python/ml_croissant/ml_croissant/_src/core/constants.py
@@ -52,7 +52,7 @@ SCHEMA_ORG_MD5 = rdflib.term.URIRef("https://schema.org/md5")
 
 TO_CROISSANT = {
     ML_COMMONS_APPLY_TRANSFORM: "apply_transform",
-    ML_COMMONS_DATA_TYPE: "data_type",
+    ML_COMMONS_DATA_TYPE: "croissant_data_type",
     ML_COMMONS_DATA: "data",
     ML_COMMONS_FORMAT: "format",
     ML_COMMONS_INCLUDES: "includes",

--- a/python/ml_croissant/ml_croissant/_src/core/constants.py
+++ b/python/ml_croissant/ml_croissant/_src/core/constants.py
@@ -52,7 +52,7 @@ SCHEMA_ORG_MD5 = rdflib.term.URIRef("https://schema.org/md5")
 
 TO_CROISSANT = {
     ML_COMMONS_APPLY_TRANSFORM: "apply_transform",
-    ML_COMMONS_DATA_TYPE: "node_data_type",
+    ML_COMMONS_DATA_TYPE: "field_data_type",
     ML_COMMONS_DATA: "data",
     ML_COMMONS_FORMAT: "format",
     ML_COMMONS_INCLUDES: "includes",

--- a/python/ml_croissant/ml_croissant/_src/core/constants.py
+++ b/python/ml_croissant/ml_croissant/_src/core/constants.py
@@ -52,7 +52,7 @@ SCHEMA_ORG_MD5 = rdflib.term.URIRef("https://schema.org/md5")
 
 TO_CROISSANT = {
     ML_COMMONS_APPLY_TRANSFORM: "apply_transform",
-    ML_COMMONS_DATA_TYPE: "croissant_data_type",
+    ML_COMMONS_DATA_TYPE: "node_data_type",
     ML_COMMONS_DATA: "data",
     ML_COMMONS_FORMAT: "format",
     ML_COMMONS_INCLUDES: "includes",

--- a/python/ml_croissant/ml_croissant/_src/datasets.py
+++ b/python/ml_croissant/ml_croissant/_src/datasets.py
@@ -18,8 +18,8 @@ from ml_croissant._src.operation_graph.operations import (
 from ml_croissant._src.structure_graph.graph import (
     check_structure_graph,
     from_file_to_json,
-    from_json_to_jsonld,
-    from_jsonld_to_nodes,
+    from_json_to_rdf,
+    from_rdf_to_nodes,
     from_nodes_to_structure_graph,
 )
 import networkx as nx
@@ -37,15 +37,15 @@ class Validator:
     def run_static_analysis(self, debug: bool = False):
         try:
             file_path, self.file = from_file_to_json(self.file_or_file_path)
-            ns, json_ld = from_json_to_jsonld(self.file)
-            nodes, parents = from_jsonld_to_nodes(self.issues, json_ld)
+            ns, json_ld = from_json_to_rdf(self.file)
+            nodes = from_rdf_to_nodes(self.issues, json_ld)
             # Print all nodes for debugging purposes.
             if debug:
                 logging.info("Found the following nodes during static analysis.")
                 for node in nodes:
                     logging.info(node)
             entry_node, structure_graph = from_nodes_to_structure_graph(
-                self.issues, nodes, parents
+                self.issues, nodes
             )
             check_structure_graph(self.issues, structure_graph)
             # Draw the structure graph for debugging purposes.

--- a/python/ml_croissant/ml_croissant/_src/datasets.py
+++ b/python/ml_croissant/ml_croissant/_src/datasets.py
@@ -16,6 +16,7 @@ from ml_croissant._src.operation_graph.operations import (
     ReadField,
 )
 from ml_croissant._src.structure_graph.graph import (
+    check_structure_graph,
     from_file_to_json,
     from_json_to_jsonld,
     from_jsonld_to_nodes,
@@ -46,13 +47,14 @@ class Validator:
             entry_node, structure_graph = from_nodes_to_structure_graph(
                 self.issues, nodes, parents
             )
+            check_structure_graph(self.issues, structure_graph)
             # Draw the structure graph for debugging purposes.
             if debug:
                 graphs_utils.pretty_print_graph(structure_graph, simplify=True)
             # Feature toggling: do not check for MovieLens, because we need more
             # features.
             if entry_node.uid == "Movielens-25M":
-                return
+                pass
             self.operations = OperationGraph.from_nodes(
                 issues=self.issues,
                 metadata=entry_node,

--- a/python/ml_croissant/ml_croissant/_src/datasets.py
+++ b/python/ml_croissant/ml_croissant/_src/datasets.py
@@ -51,10 +51,6 @@ class Validator:
             # Draw the structure graph for debugging purposes.
             if debug:
                 graphs_utils.pretty_print_graph(structure_graph, simplify=True)
-            # Feature toggling: do not check for MovieLens, because we need more
-            # features.
-            if entry_node.uid == "Movielens-25M":
-                pass
             self.operations = OperationGraph.from_nodes(
                 issues=self.issues,
                 metadata=entry_node,

--- a/python/ml_croissant/ml_croissant/_src/datasets_test.py
+++ b/python/ml_croissant/ml_croissant/_src/datasets_test.py
@@ -18,7 +18,7 @@ import pytest
         ],
         [
             "metadata_bad_type.json",
-            'Node should have an attribute `"@type" in',
+            'No metadata is defined in the dataset',
         ],
         # Distribution.
         [

--- a/python/ml_croissant/ml_croissant/_src/datasets_test.py
+++ b/python/ml_croissant/ml_croissant/_src/datasets_test.py
@@ -58,7 +58,7 @@ import pytest
         ],
         [
             "recordset_missing_context_for_datatype.json",
-            "The field does not specify any dataType",
+            "The field does not specify any http://mlcommons.org/schema/dataType",
         ],
         # ML field.
         [

--- a/python/ml_croissant/ml_croissant/_src/datasets_test.py
+++ b/python/ml_croissant/ml_croissant/_src/datasets_test.py
@@ -58,10 +58,7 @@ import pytest
         ],
         [
             "recordset_missing_context_for_datatype.json",
-            (
-                'Property "http://mlcommons.org/schema/dataType" is mandatory, but does'
-                " not exist."
-            ),
+            "The field does not specify any dataType",
         ],
         # ML field.
         [

--- a/python/ml_croissant/ml_croissant/_src/operation_graph/graph.py
+++ b/python/ml_croissant/ml_croissant/_src/operation_graph/graph.py
@@ -77,7 +77,7 @@ def _add_operations_for_field_with_source(
     for predecessor in graph.predecessors(node):
         operations.add_edge(last_operation[predecessor], join)
     if len(node.source.reference) != 2:
-        node.add_error(f'Wrong source for the node')
+        node.add_error('Wrong source for the node')
         return
     # Read/extract the field
     read_field = ReadField(node=node, rdf_namespace_manager=rdf_namespace_manager)
@@ -203,7 +203,7 @@ class OperationGraph:
                 )
 
         # Attach all entry nodes to a single `start` node
-        entry_operations = get_entry_nodes(issues, operations)
+        entry_operations = get_entry_nodes(operations)
         init_operation = InitOperation(node=metadata)
         for entry_operation in entry_operations:
             operations.add_edge(init_operation, entry_operation)

--- a/python/ml_croissant/ml_croissant/_src/operation_graph/graph.py
+++ b/python/ml_croissant/ml_croissant/_src/operation_graph/graph.py
@@ -77,7 +77,7 @@ def _add_operations_for_field_with_source(
     for predecessor in graph.predecessors(node):
         operations.add_edge(last_operation[predecessor], join)
     if len(node.source.reference) != 2:
-        issues.add_error(f'Wrong source in node "{node.uid}"')
+        node.add_error(f'Wrong source for the node')
         return
     # Read/extract the field
     read_field = ReadField(node=node, rdf_namespace_manager=rdf_namespace_manager)

--- a/python/ml_croissant/ml_croissant/_src/operation_graph/operations/field.py
+++ b/python/ml_croissant/ml_croissant/_src/operation_graph/operations/field.py
@@ -41,7 +41,7 @@ class ReadField(Operation):
         raise ValueError(f'No data type found for "{self.node.uid}"')
 
     def _cast_value(self, value: Any):
-        data_type = self.find_data_type(self.node.croissant_data_type)
+        data_type = self.find_data_type(self.node.node_data_type)
         if pd.isna(value):
             return value
         try:

--- a/python/ml_croissant/ml_croissant/_src/operation_graph/operations/field.py
+++ b/python/ml_croissant/ml_croissant/_src/operation_graph/operations/field.py
@@ -41,7 +41,7 @@ class ReadField(Operation):
         raise ValueError(f'No data type found for "{self.node.uid}"')
 
     def _cast_value(self, value: Any):
-        data_type = self.find_data_type(self.node.data_type)
+        data_type = self.find_data_type(self.node.croissant_data_type)
         if pd.isna(value):
             return value
         try:

--- a/python/ml_croissant/ml_croissant/_src/operation_graph/operations/field.py
+++ b/python/ml_croissant/ml_croissant/_src/operation_graph/operations/field.py
@@ -41,7 +41,7 @@ class ReadField(Operation):
         raise ValueError(f'No data type found for "{self.node.uid}"')
 
     def _cast_value(self, value: Any):
-        data_type = self.find_data_type(self.node.node_data_type)
+        data_type = self.find_data_type(self.node.field_data_type)
         if pd.isna(value):
             return value
         try:

--- a/python/ml_croissant/ml_croissant/_src/operation_graph/operations/join.py
+++ b/python/ml_croissant/ml_croissant/_src/operation_graph/operations/join.py
@@ -1,9 +1,7 @@
 """Join operation module."""
 
-from collections.abc import Callable
 import dataclasses
 import re
-from typing import Any
 
 from ml_croissant._src.structure_graph.nodes import Source
 from ml_croissant._src.operation_graph.base_operation import Operation

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/base_node.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/base_node.py
@@ -4,11 +4,9 @@ import abc
 import dataclasses
 import re
 
-import networkx as nx
-import rdflib
-
 from ml_croissant._src.core import constants
 from ml_croissant._src.core.issues import Context, Issues
+from rdflib import term
 
 ID_REGEX = "[a-zA-Z0-9\\-_\\.]+"
 _MAX_ID_LENGTH = 255
@@ -29,50 +27,20 @@ class Node(abc.ABC):
 
     Args:
         issues: the issues that will be modified in-place.
-        graph: The NetworkX RDF graph to validate.
-        node: The node in the graph to convert.
+        bnode: The RDF BNode.
+        parents: The parent nodes in the Croissant JSON-LD as a tuple.
         name: The name of the node.
-        rdf_id: The RDF @id created by RDFLib.
-        uid: Croissant unique identifier. It's the concatenation of the path within
-            the Croissant hierarchy. For instance, for a field:
-            dataset.name/record_set.name/field.name.
-        context: Context of the node in the Croissant hierarchy (dataset, distribution,
-            record set, field).
-
-    Usage:
-
-    ```python
-    node = Node(issues=issues, graph=graph, node=source)
-
-    # Can access a property of the node:
-    citation = node["https://schema.org/citation"]
-
-    # Can check a property exists:
-    has_citation = "https://schema.org/citation" in node
-
-    # Can assert features on the node. E.g.:
-    node.assert_has_exclusive_properties(
-        [[""https://schema.org/sha256"", "https://schema.org/md5"]]
-    )
-    ```
     """
 
     issues: Issues
-    graph: nx.MultiDiGraph = None
-    node: rdflib.term.BNode = None
+    bnode: term.BNode
+    parents: tuple["Node", ...]
     name: str = ""
-    rdf_id: str | None = None
-    uid: str | None = None
-    context: Context | None = None
 
     def __post_init__(self):
         """Checks for `name` (common property between all nodes)."""
         self.assert_has_mandatory_properties("name")
         validate_name(self.issues, self.name)
-
-    @property
-    def _edges_from_node(self):
-        return self.graph.edges(self.node, keys=True)
 
     def assert_has_mandatory_properties(self, *mandatory_properties: str):
         """Checks a node in the graph for existing properties with constraints.
@@ -137,13 +105,30 @@ class Node(abc.ABC):
 
     def __repr__(self):
         attributes = self.__dict__.copy()
-        attributes_to_remove = ["context", "graph", "issues", "node", "rdf_id", "uid"]
+        attributes_to_remove = ["bnode", "issues", "parents"]
         for attribute in self.__dict__:
             if attributes[attribute] is None or attribute in attributes_to_remove:
                 del attributes[attribute]
         attributes_items = sorted(list(attributes.items()))
         attributes_str = ", ".join(f"{key}={value}" for key, value in attributes_items)
         return f"{self.__class__.__name__}(uid={self.uid}, {attributes_str})"
+
+    @property
+    def uid(self):
+        if len(self.parents) <= 1:
+            return self.name
+        return f"{self.parents[-1].uid}/{self.name}"
+
+    @property
+    def context(self):
+        nodes = self.parents + (self,)
+        return Context(
+            dataset_name=_get_element(nodes, ["Metadata"]),
+            distribution_name=_get_element(nodes, ["FileObject", "FileSet"]),
+            record_set_name=_get_element(nodes, ["RecordSet"]),
+            field_name=_get_element(nodes, ["Field"]),
+            sub_field_name=_get_element(nodes, []),
+        )
 
 
 def validate_name(issues: Issues, name: str):
@@ -166,3 +151,9 @@ def there_exists_at_least_one_property(node: Node, possible_properties: list[str
         if getattr(node, possible_property, None) is not None:
             return True
     return False
+
+
+def _get_element(nodes: tuple[Node, ...], cls_names: list[str]):
+    return next(
+        (node.name for node in nodes if node.__class__.__name__ in cls_names), None
+    )

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/base_node.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/base_node.py
@@ -7,6 +7,7 @@ import re
 from ml_croissant._src.core import constants
 from ml_croissant._src.core.issues import Context, Issues
 from rdflib import term
+import networkx as nx
 
 ID_REGEX = "[a-zA-Z0-9\\-_\\.]+"
 _MAX_ID_LENGTH = 255
@@ -27,15 +28,17 @@ class Node(abc.ABC):
 
     Args:
         issues: the issues that will be modified in-place.
-        bnode: The RDF BNode.
+        bnode: The RDF BNode this node is based on.
+        graph: The structure graph.
         parents: The parent nodes in the Croissant JSON-LD as a tuple.
         name: The name of the node.
     """
 
     issues: Issues
     bnode: term.BNode
+    graph: nx.MultiDiGraph
     parents: tuple["Node", ...]
-    name: str = ""
+    name: str
 
     def __post_init__(self):
         """Checks for `name` (common property between all nodes)."""
@@ -105,7 +108,7 @@ class Node(abc.ABC):
 
     def __repr__(self):
         attributes = self.__dict__.copy()
-        attributes_to_remove = ["bnode", "issues", "parents"]
+        attributes_to_remove = ["bnode", "graph", "issues", "parents"]
         for attribute in self.__dict__:
             if attributes[attribute] is None or attribute in attributes_to_remove:
                 del attributes[attribute]

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/base_node.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/base_node.py
@@ -137,13 +137,13 @@ class Node(abc.ABC):
 
     def __repr__(self):
         attributes = self.__dict__.copy()
-        attributes_to_remove = ["context", "graph", "issues", "node"]
-        for attribute in attributes_to_remove:
-            if attribute in attributes:
+        attributes_to_remove = ["context", "graph", "issues", "node", "rdf_id", "uid"]
+        for attribute in self.__dict__:
+            if attributes[attribute] is None or attribute in attributes_to_remove:
                 del attributes[attribute]
         attributes_items = sorted(list(attributes.items()))
         attributes_str = ", ".join(f"{key}={value}" for key, value in attributes_items)
-        return f"{self.__class__.__name__}({attributes_str})"
+        return f"{self.__class__.__name__}(uid={self.uid}, {attributes_str})"
 
 
 def validate_name(issues: Issues, name: str):

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/base_node_test.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/base_node_test.py
@@ -4,6 +4,7 @@ import dataclasses
 
 from ml_croissant._src.core.issues import Issues
 from ml_croissant._src.structure_graph import base_node
+import networkx as nx
 from rdflib import term
 
 
@@ -19,6 +20,7 @@ def test_there_exists_at_least_one_property():
     node = Node(
         issues=Issues(),
         bnode=term.BNode("rdf_id"),
+        graph=nx.MultiDiGraph(),
         parents=(),
         name="name",
         property1="property1",
@@ -43,6 +45,7 @@ def test_repr():
     node = MyNode(
         issues=Issues(),
         bnode=term.BNode("rdf_id"),
+        graph=nx.MultiDiGraph(),
         parents=(),
         name="name",
         foo="foo",

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/base_node_test.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/base_node_test.py
@@ -4,6 +4,7 @@ import dataclasses
 
 from ml_croissant._src.core.issues import Issues
 from ml_croissant._src.structure_graph import base_node
+from rdflib import term
 
 
 def test_there_exists_at_least_one_property():
@@ -15,7 +16,14 @@ def test_there_exists_at_least_one_property():
         def check(self):
             pass
 
-    node = Node(issues=Issues(), property1="property1", property2="property2")
+    node = Node(
+        issues=Issues(),
+        bnode=term.BNode("rdf_id"),
+        parents=(),
+        name="name",
+        property1="property1",
+        property2="property2",
+    )
     assert base_node.there_exists_at_least_one_property(
         node, ["property0", "property1"]
     )
@@ -32,5 +40,11 @@ def test_repr():
         def check(self):
             pass
 
-    node = MyNode(issues=Issues(), name="NAME", foo="bar", rdf_id="RDF_IR", uid="UID")
-    assert str(node) == "MyNode(uid=UID, foo=bar, name=NAME)"
+    node = MyNode(
+        issues=Issues(),
+        bnode=term.BNode("rdf_id"),
+        parents=(),
+        name="name",
+        foo="foo",
+    )
+    assert str(node) == "MyNode(uid=name, foo=foo, name=name)"

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/base_node_test.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/base_node_test.py
@@ -27,9 +27,10 @@ def test_repr():
     @dataclasses.dataclass(frozen=True, repr=False)
     class MyNode(base_node.Node):
         foo: str = ""
+        bar: str | None = None
 
         def check(self):
             pass
 
     node = MyNode(issues=Issues(), name="NAME", foo="bar", rdf_id="RDF_IR", uid="UID")
-    assert str(node) == "MyNode(foo=bar, name=NAME, rdf_id=RDF_IR, uid=UID)"
+    assert str(node) == "MyNode(uid=UID, foo=bar, name=NAME)"

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/graph.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/graph.py
@@ -96,9 +96,17 @@ def _parse_node_params(
             if isinstance(_object, term.Literal):
                 node_params[croissant_key] = str(_object)
             elif isinstance(_object, term.BNode):
-                node_params[croissant_key] = _parse_node_params(
+                current_node_params = _parse_node_params(
                     issues, rdf_graph, _object, no_filter=True
                 )
+                if croissant_key not in node_params:
+                    node_params[croissant_key] = [current_node_params]
+                elif isinstance(node_params[croissant_key], list):
+                    node_params[croissant_key].append(current_node_params)
+                else:
+                    raise ValueError("Recursive calls should always be lists.")
+            else:
+                raise ValueError("Objects are either Bnodes or Literals.")
     # Parse `source`.
     if (source := node_params.get("source")) is not None:
         node_params["source"] = Source.from_json_ld(issues, source)

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/graph_test.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/graph_test.py
@@ -1,201 +1,64 @@
 """graph_test module."""
 
-from typing import Any
-
-from ml_croissant._src.core.issues import Context, Issues
+from ml_croissant._src.core import constants
+from ml_croissant._src.core.issues import Issues
 from ml_croissant._src.structure_graph.graph import (
-    from_json_to_jsonld,
-    from_jsonld_to_nodes,
-    Json,
-    JsonLd,
+    from_rdf_to_nodes,
 )
 from ml_croissant._src.structure_graph.nodes import (
     FileObject,
     Metadata,
 )
+import rdflib
+from rdflib import term
 
+Literal = term.Literal
 
-def _remove_keys(json: Json | JsonLd, keys: list[str]) -> Any:
-    """Edits a dict in place by removing the `keys` recursively."""
-    if isinstance(json, dict):
-        for key, value in json.copy().items():
-            if key in keys:
-                del json[key]
-            elif isinstance(value, (dict, list)):
-                json[key] = _remove_keys(json[key], keys)
-    elif isinstance(json, list):
-        return [_remove_keys(element, keys) for element in json]
-    return json
-
-
-def assert_jsons_are_equal(json1: JsonLd, json2: JsonLd, ignore_keys: list[str] = []):
-    """Asserts two JSONs are equal by ignoring some keys."""
-    _remove_keys(json1, ignore_keys)
-    _remove_keys(json2, ignore_keys)
-    assert json1 == json2
-
-
-def test_remove_keys():
-    json = {"foo": "foo", "bar": [{"foo": "foo", "bar": "bar"}]}
-    _remove_keys(json, ["foo"])
-    assert json == {"bar": [{"bar": "bar"}]}
-
-
-def test_from_json_to_jsonld():
-    json = {
-        "@context": {
-            "@vocab": "https://schema.org/",
-            "sc": "https://schema.org/",
-            "ml": "http://mlcommons.org/schema/",
-            "includes": "ml:includes",
-            "recordSet": "ml:RecordSet",
-            "field": "ml:Field",
-            "subField": "ml:SubField",
-            "dataType": "ml:dataType",
-            "source": "ml:source",
-            "data": "ml:data",
-            "applyTransform": "ml:applyTransform",
-            "format": "ml:format",
-            "regex": "ml:regex",
-            "separator": "ml:separator",
-        },
-        "@type": "sc:Dataset",
-        "@language": "en",
-        "name": "mydataset",
-        "url": "https://www.google.com/dataset",
-        "description": "This is a description.",
-        "license": "This is a license.",
-        "citation": "This is a citation.",
-        "distribution": [
-            {
-                "name": "a-csv-table",
-                "@type": "sc:FileObject",
-                "contentUrl": "ratings.csv",
-                "encodingFormat": "text/csv",
-                "sha256": "xxx",
-            }
-        ],
-        "recordSet": [
-            {
-                "name": "annotations",
-                "@type": "ml:RecordSet",
-                "field": [
-                    {
-                        "name": "bbox",
-                        "@type": "ml:Field",
-                        "description": "The bounding box around annotated object[s].",
-                        "dataType": "ml:BoundingBox",
-                        "source": {
-                            "data": "#{a-csv-table/annotations}",
-                            "format": "XYWH",
-                        },
-                    },
-                ],
-            },
-        ],
-    }
-    expected_json_ld = [
-        {
-            "@type": ["https://schema.org/Dataset"],
-            "http://mlcommons.org/schema/RecordSet": [{}],
-            "https://schema.org/@language": [{"@value": "en"}],
-            "https://schema.org/citation": [{"@value": "This is a citation."}],
-            "https://schema.org/description": [{"@value": "This is a description."}],
-            "https://schema.org/distribution": [{}],
-            "https://schema.org/license": [{"@value": "This is a license."}],
-            "https://schema.org/name": [{"@value": "mydataset"}],
-            "https://schema.org/url": [{"@value": "https://www.google.com/dataset"}],
-        },
-        {
-            "@type": ["https://schema.org/FileObject"],
-            "https://schema.org/contentUrl": [{"@value": "ratings.csv"}],
-            "https://schema.org/encodingFormat": [{"@value": "text/csv"}],
-            "https://schema.org/name": [{"@value": "a-csv-table"}],
-            "https://schema.org/sha256": [{"@value": "xxx"}],
-        },
-        {
-            "@type": ["http://mlcommons.org/schema/RecordSet"],
-            "http://mlcommons.org/schema/Field": [{}],
-            "https://schema.org/name": [{"@value": "annotations"}],
-        },
-        {
-            "@type": ["http://mlcommons.org/schema/Field"],
-            "http://mlcommons.org/schema/dataType": [{"@value": "ml:BoundingBox"}],
-            "http://mlcommons.org/schema/source": [{}],
-            "https://schema.org/description": [
-                {"@value": "The bounding box around annotated object[s]."}
-            ],
-            "https://schema.org/name": [{"@value": "bbox"}],
-        },
-        {
-            "http://mlcommons.org/schema/data": [
-                {"@value": "#{a-csv-table/annotations}"}
-            ],
-            "http://mlcommons.org/schema/format": [{"@value": "XYWH"}],
-        },
-    ]
-    _, json_ld = from_json_to_jsonld(json)
-    # We ignore `@id`, because they can change.
-    assert_jsons_are_equal(expected_json_ld, json_ld, ignore_keys=["@id"])
-
-
-def test_from_jsonld_to_nodes():
+def test_from_rdf_to_nodes():
     issues = Issues()
-    json_ld = [
-        {
-            "@id": "ID_DATASET",
-            "@type": ["https://schema.org/Dataset"],
-            "https://schema.org/@language": [{"@value": "en"}],
-            "https://schema.org/citation": [{"@value": "This is a citation."}],
-            "https://schema.org/description": [{"@value": "This is a description."}],
-            "https://schema.org/license": [{"@value": "This is a license."}],
-            "https://schema.org/name": [{"@value": "mydataset"}],
-            "https://schema.org/url": [{"@value": "https://www.google.com/dataset"}],
-            "https://schema.org/distribution": [{"@id": "ID_FILE_OBJECT"}],
-        },
-        {
-            "@id": "ID_FILE_OBJECT",
-            "@type": ["https://schema.org/FileObject"],
-            "https://schema.org/name": [{"@value": "a-csv-table"}],
-            "https://schema.org/contentUrl": [{"@value": "ratings.csv"}],
-            "https://schema.org/encodingFormat": [{"@value": "text/csv"}],
-            "https://schema.org/sha256": [{"@value": "xxx"}],
-        },
-    ]
+    graph = rdflib.Graph()
+    bnode1 = term.BNode("ID_DATASET")
+    bnode2 = term.BNode("ID_FILE_OBJECT")
+
+    # Metadata
+    graph.add((bnode1, constants.RDF_TYPE, constants.SCHEMA_ORG_DATASET))
+    graph.add((bnode1, constants.SCHEMA_ORG_CITATION, Literal("Citation.")))
+    graph.add((bnode1, constants.SCHEMA_ORG_DESCRIPTION, Literal("Description.")))
+    graph.add((bnode1, constants.SCHEMA_ORG_LICENSE, Literal("License.")))
+    graph.add((bnode1, constants.SCHEMA_ORG_NAME, Literal("mydataset")))
+    graph.add((bnode1, constants.SCHEMA_ORG_URL, Literal("google.com/dataset")))
+    graph.add((bnode1, constants.SCHEMA_ORG_DISTRIBUTION, bnode2))
+
+    # FileObject
+    graph.add((bnode2, constants.RDF_TYPE, constants.SCHEMA_ORG_FILE_OBJECT))
+    graph.add((bnode2, constants.SCHEMA_ORG_NAME, Literal("a-csv-table")))
+    graph.add((bnode2, constants.SCHEMA_ORG_CONTENT_URL, Literal("ratings.csv")))
+    graph.add((bnode2, constants.SCHEMA_ORG_ENCODING_FORMAT, Literal("text/csv")))
+    graph.add((bnode2, constants.SCHEMA_ORG_SHA256, Literal("xxx")))
+
+    metadata = Metadata(
+        issues=issues,
+        bnode=bnode1,
+        parents=(),
+        name="mydataset",
+        citation="Citation.",
+        description="Description.",
+        license="License.",
+        url="google.com/dataset",
+    )
     expected_nodes = [
-        Metadata(
-            issues=issues,
-            name="mydataset",
-            rdf_id="ID_DATASET",
-            uid="mydataset",
-            citation="This is a citation.",
-            description="This is a description.",
-            license="This is a license.",
-            url="https://www.google.com/dataset",
-            context=Context(
-                dataset_name="mydataset",
-                distribution_name=None,
-                record_set_name=None,
-                field_name=None,
-                sub_field_name=None,
-            ),
-        ),
+        metadata,
         FileObject(
             issues=issues,
+            bnode=bnode2,
+            parents=(metadata,),
             name="a-csv-table",
-            rdf_id="ID_FILE_OBJECT",
-            uid="a-csv-table",
             content_url="ratings.csv",
             encoding_format="text/csv",
             sha256="xxx",
-            context=Context(
-                dataset_name="mydataset",
-                distribution_name="a-csv-table",
-                record_set_name=None,
-                field_name=None,
-                sub_field_name=None,
-            ),
         ),
     ]
-    nodes, _ = from_jsonld_to_nodes(issues, json_ld)
-    assert nodes == expected_nodes
+    nodes = from_rdf_to_nodes(issues, graph)
+    assert not issues.errors
+    assert not issues.warnings
+    assert nodes[0] == expected_nodes[0]

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/graph_test.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/graph_test.py
@@ -36,9 +36,12 @@ def test_from_rdf_to_nodes():
     graph.add((bnode2, constants.SCHEMA_ORG_ENCODING_FORMAT, Literal("text/csv")))
     graph.add((bnode2, constants.SCHEMA_ORG_SHA256, Literal("xxx")))
 
+    nodes = from_rdf_to_nodes(issues, graph)
+    structure_graph = nodes[0].graph
     metadata = Metadata(
         issues=issues,
         bnode=bnode1,
+        graph=structure_graph,
         parents=(),
         name="mydataset",
         citation="Citation.",
@@ -51,6 +54,7 @@ def test_from_rdf_to_nodes():
         FileObject(
             issues=issues,
             bnode=bnode2,
+            graph=structure_graph,
             parents=(metadata,),
             name="a-csv-table",
             content_url="ratings.csv",
@@ -58,7 +62,6 @@ def test_from_rdf_to_nodes():
             sha256="xxx",
         ),
     ]
-    nodes = from_rdf_to_nodes(issues, graph)
     assert not issues.errors
     assert not issues.warnings
-    assert nodes[0] == expected_nodes[0]
+    assert nodes == expected_nodes

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/__init__.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/__init__.py
@@ -4,6 +4,7 @@ from ml_croissant._src.structure_graph.nodes.file_set import FileSet
 from ml_croissant._src.structure_graph.nodes.metadata import Metadata
 from ml_croissant._src.structure_graph.nodes.record_set import RecordSet
 from ml_croissant._src.structure_graph.nodes.source import Source
+from ml_croissant._src.structure_graph.nodes.source import Transform
 
 __all__ = [
     "Field",
@@ -12,4 +13,5 @@ __all__ = [
     "Metadata",
     "RecordSet",
     "Source",
+    "Transform",
 ]

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/field.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/field.py
@@ -14,10 +14,11 @@ class Field(Node):
     """Nodes to describe a dataset Field."""
 
     data: list[Mapping[str, Any]] | None = None
-    croissant_data_type: str | None = None
     description: str | None = None
     has_sub_fields: bool | None = None
     name: str = ""
+    # `node_data_type` is different than `node.data_type`. See `data_type` docstring.
+    node_data_type: str | None = None
     references: Source = dataclasses.field(default_factory=Source)
     source: Source = dataclasses.field(default_factory=Source)
 
@@ -27,8 +28,13 @@ class Field(Node):
         # TODO(marcenacp): check that `data` has the expected form if it exists.
 
     def data_type(self, graph: nx.MultiDiGraph) -> str | None:
-        if self.croissant_data_type is not None:
-            return self.croissant_data_type
+        """Retrieves the actual data type of the node.
+
+        The data_type can be either directly on the node (`node_data_type`) or on one
+        of the parent fields.
+        """
+        if self.node_data_type is not None:
+            return self.node_data_type
         parent = next(graph.predecessors(self), None)
         if parent is None or not isinstance(parent, Field):
             self.add_error(

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/field.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/field.py
@@ -6,13 +6,15 @@ from typing import Any
 
 from ml_croissant._src.structure_graph.base_node import Node
 from ml_croissant._src.structure_graph.nodes.source import Source
+import networkx as nx
+
 
 @dataclasses.dataclass(frozen=True, repr=False)
 class Field(Node):
     """Nodes to describe a dataset Field."""
 
     data: list[Mapping[str, Any]] | None = None
-    data_type: str | None = None
+    croissant_data_type: str | None = None
     description: str | None = None
     has_sub_fields: bool | None = None
     name: str = ""
@@ -20,6 +22,18 @@ class Field(Node):
     source: Source = dataclasses.field(default_factory=Source)
 
     def check(self):
-        self.assert_has_mandatory_properties("data_type", "name")
+        self.assert_has_mandatory_properties("name")
         self.assert_has_optional_properties("description")
         # TODO(marcenacp): check that `data` has the expected form if it exists.
+
+    def data_type(self, graph: nx.MultiDiGraph) -> str | None:
+        if self.croissant_data_type is not None:
+            return self.croissant_data_type
+        parent = next(graph.predecessors(self), None)
+        if parent is None or not isinstance(parent, Field):
+            self.add_error(
+                "The field does not specify any dataType, neither does any of its"
+                " predecessor."
+            )
+            return None
+        return parent.data_type(graph)

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/source.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/source.py
@@ -25,6 +25,13 @@ def parse_reference(issues: Issues, source_data: str) -> tuple[str, ...]:
 
 
 @dataclasses.dataclass(frozen=True)
+class Transform:
+    regex: str | None = None
+    replace: str | None = None
+    separator: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
 class Source:
     """Standardizes the usage of sources.
 
@@ -51,29 +58,40 @@ class Source:
     """
 
     reference: tuple[str, ...] = ()
-    apply_transform_regex: str | None = None
-    apply_transform_separator: str | None = None
+    apply_transform: tuple[Transform, ...] = ()
 
     @classmethod
     def from_json_ld(cls, issues: Issues, field: Any) -> "Source":
         if isinstance(field, str):
             return cls(reference=parse_reference(issues, field))
+        elif isinstance(field, list):
+            if len(field) != 1:
+                raise ValueError(f"Field {field} should have one element.")
+            return Source.from_json_ld(issues, field[0])
         elif isinstance(field, dict):
             try:
-                apply_transform = field.get("apply_transform", {})
+                transforms = field.get("apply_transform", [])
+                if not isinstance(transforms, list):
+                    raise ValueError(
+                        'Field "apply_transform" should be parsed as a list.'
+                    )
+                transforms = tuple(Transform(
+                    regex=transform.get("regex"),
+                    replace=transform.get("replace"),
+                    separator=transform.get("separator"),
+                ) for transform in transforms)
                 return cls(
                     reference=parse_reference(issues, field.get("data")),
-                    apply_transform_regex=apply_transform.get("regex"),
-                    apply_transform_separator=apply_transform.get("separator"),
+                    apply_transform=transforms,
                 )
             except (IndexError, TypeError) as exception:
                 issues.add_error(
                     f"Malformed `source`: {field}. Got exception: {exception}"
                 )
-                return cls(reference=())
+                return cls()
         else:
             issues.add_error(f"`source` has wrong type: {type(field)} ({field})")
-            return cls(reference=())
+            return cls()
 
     def __bool__(self):
         """Allows to write `if not node.source` / `if node.source`"""

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_missing_context_for_datatype.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_missing_context_for_datatype.json
@@ -40,7 +40,8 @@
         {
           "name": "first-field",
           "@type": "ml:Field",
-          "dataType": "sc:Integer"
+          "dataType": "sc:Integer",
+          "source": "#{a-csv-table/column}"
         }
       ]
     }

--- a/python/ml_croissant/ml_croissant/_src/tests/nodes.py
+++ b/python/ml_croissant/ml_croissant/_src/tests/nodes.py
@@ -3,6 +3,7 @@
 from ml_croissant._src.core.issues import Issues
 from ml_croissant._src.structure_graph.base_node import Node
 from ml_croissant._src.structure_graph.nodes import Field, FileObject, FileSet
+import networkx as nx
 from rdflib import term
 
 
@@ -14,6 +15,7 @@ class _EmptyNode(Node):
 empty_node = _EmptyNode(
     issues=Issues(),
     bnode=term.BNode("rdf_id"),
+    graph=nx.MultiDiGraph(),
     name="node_name",
     parents=(),
 )
@@ -21,6 +23,7 @@ empty_node = _EmptyNode(
 empty_field = Field(
     issues=Issues(),
     bnode=term.BNode("rdf_id"),
+    graph=nx.MultiDiGraph(),
     name="field_name",
     parents=(),
 )
@@ -28,6 +31,7 @@ empty_field = Field(
 empty_file_object = FileObject(
     issues=Issues(),
     bnode=term.BNode("rdf_id"),
+    graph=nx.MultiDiGraph(),
     name="file_object_name",
     parents=(),
 )
@@ -35,6 +39,7 @@ empty_file_object = FileObject(
 empty_file_set = FileSet(
     issues=Issues(),
     bnode=term.BNode("rdf_id"),
+    graph=nx.MultiDiGraph(),
     name="file_set_name",
     parents=(),
 )

--- a/python/ml_croissant/ml_croissant/_src/tests/nodes.py
+++ b/python/ml_croissant/ml_croissant/_src/tests/nodes.py
@@ -3,6 +3,7 @@
 from ml_croissant._src.core.issues import Issues
 from ml_croissant._src.structure_graph.base_node import Node
 from ml_croissant._src.structure_graph.nodes import Field, FileObject, FileSet
+from rdflib import term
 
 
 class _EmptyNode(Node):
@@ -12,32 +13,28 @@ class _EmptyNode(Node):
 
 empty_node = _EmptyNode(
     issues=Issues(),
-    graph=None,
-    node=None,
+    bnode=term.BNode("rdf_id"),
     name="node_name",
-    uid="node_name",
+    parents=(),
 )
 
 empty_field = Field(
     issues=Issues(),
-    graph=None,
-    node=None,
+    bnode=term.BNode("rdf_id"),
     name="field_name",
-    uid="field_name",
+    parents=(),
 )
 
 empty_file_object = FileObject(
     issues=Issues(),
-    graph=None,
-    node=None,
+    bnode=term.BNode("rdf_id"),
     name="file_object_name",
-    uid="file_object_name",
+    parents=(),
 )
 
 empty_file_set = FileSet(
     issues=Issues(),
-    graph=None,
-    node=None,
+    bnode=term.BNode("rdf_id"),
     name="file_set_name",
-    uid="file_set_name",
+    parents=(),
 )


### PR DESCRIPTION
Features:

- The verifier now supports `apply_transform` passed as a list (like in wiki-text).
- Fields can check their data type (`field.data_type`) from any parent fields if it's not declared on them directly (like in movielens).

Note: this PR adds back movielens to the "structure" verifier, but not to the "operation" verifier (still an early return).

Fixes: https://github.com/mlcommons/croissant/issues/103
Fixes: https://github.com/mlcommons/croissant/issues/101