### PR TITLE
Differentiate between attributes (ml:recordSet) and types (ml:RecordSet)

### DIFF
--- a/datasets/birds/birds_by_openml_converter.json
+++ b/datasets/birds/birds_by_openml_converter.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",
@@ -41,13 +41,15 @@
   "license": "Public",
   "url": "https://www.openml.org/search?type=data&id=41464",
   "version": "4",
-  "distribution": {
-    "@type": "sc:FileObject",
-    "name": "birds.arff",
-    "contentUrl": "https://api.openml.org/data/v1/download/21230421/birds.arff",
-    "encodingFormat": "text/plain",
-    "md5": "6c69596d2dbd1add5e9a22352fa71e30"
-  },
+  "distribution": [
+    {
+      "@type": "sc:FileObject",
+      "name": "birds.arff",
+      "contentUrl": "https://api.openml.org/data/v1/download/21230421/birds.arff",
+      "encodingFormat": "text/plain",
+      "md5": "6c69596d2dbd1add5e9a22352fa71e30"
+    }
+  ],
   "recordSet": [
     {
       "@type": "ml:RecordSet",

--- a/datasets/coco2014-mini/metadata.json
+++ b/datasets/coco2014-mini/metadata.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",

--- a/datasets/coco2014/metadata.json
+++ b/datasets/coco2014/metadata.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",

--- a/datasets/movielens/metadata.json
+++ b/datasets/movielens/metadata.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",

--- a/datasets/pass-mini/metadata.json
+++ b/datasets/pass-mini/metadata.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",

--- a/datasets/pass/metadata.json
+++ b/datasets/pass/metadata.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",

--- a/datasets/recipes/compressed_archive.json
+++ b/datasets/recipes/compressed_archive.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",

--- a/datasets/recipes/enum.json
+++ b/datasets/recipes/enum.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",

--- a/datasets/recipes/minimal.json
+++ b/datasets/recipes/minimal.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",

--- a/datasets/recipes/minimal_recommended.json
+++ b/datasets/recipes/minimal_recommended.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",
@@ -33,13 +33,15 @@
   "description": "This is a minimal example, including the required and the recommended fields.",
   "license": "https://creativecommons.org/licenses/by/4.0/",
   "url": "https://example.com/dataset/recipes/minimal-recommended",
-  "distribution": {
-    "@type": "sc:FileObject",
-    "name": "minimal.csv",
-    "contentUrl": "data/minimal.csv",
-    "encodingFormat": "text/csv",
-    "sha256": "48a7c257f3c90b2a3e529ddd2cca8f4f1bd8e49ed244ef53927649504ac55354"
-  },
+  "distribution": [
+    {
+      "@type": "sc:FileObject",
+      "name": "minimal.csv",
+      "contentUrl": "data/minimal.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "48a7c257f3c90b2a3e529ddd2cca8f4f1bd8e49ed244ef53927649504ac55354"
+    }
+  ],
   "recordSet": [
     {
       "@type": "ml:RecordSet",

--- a/datasets/recipes/simple-split.json
+++ b/datasets/recipes/simple-split.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",
@@ -34,13 +34,15 @@
   "@language": "en",
   "license": "https://creativecommons.org/licenses/by/4.0/",
   "url": "https://mlcommons.org",
-  "distribution": {
-    "@type": "sc:FileObject",
-    "name": "books.csv",
-    "contentUrl": "data/books.csv",
-    "encodingFormat": "text/csv",
-    "sha256": "d35c5a01eecbd7700faf86b4ec838eb65bd6e861633b1e10ca3294d4e58e75c9"
-  },
+  "distribution": [
+    {
+      "@type": "sc:FileObject",
+      "name": "books.csv",
+      "contentUrl": "data/books.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "d35c5a01eecbd7700faf86b4ec838eb65bd6e861633b1e10ca3294d4e58e75c9"
+    }
+  ],
   "recordSet": [
     {
       "@type": "ml:RecordSet",

--- a/datasets/simple-dataset/metadata.json
+++ b/datasets/simple-dataset/metadata.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",

--- a/datasets/simple-join/metadata.json
+++ b/datasets/simple-join/metadata.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",
@@ -34,13 +34,15 @@
   "@language": "en",
   "license": "https://creativecommons.org/licenses/by/4.0/",
   "url": "https://mlcommons.org",
-  "distribution": {
-    "@type": "sc:FileObject",
-    "name": "publications",
-    "contentUrl": "data/publications.csv",
-    "encodingFormat": "text/csv",
-    "sha256": "d1bd4b903d5de29e6d455f28a68aff7095d3393a19a7cdfdeea3b9ad799e1ce1"
-  },
+  "distribution": [
+    {
+      "@type": "sc:FileObject",
+      "name": "publications",
+      "contentUrl": "data/publications.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "d1bd4b903d5de29e6d455f28a68aff7095d3393a19a7cdfdeea3b9ad799e1ce1"
+    }
+  ],
   "recordSet": [
     {
       "@type": "ml:RecordSet",

--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",

--- a/datasets/titanic/titanic_by_openml_converter.json
+++ b/datasets/titanic/titanic_by_openml_converter.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",
@@ -40,13 +40,15 @@
   "license": "Public",
   "url": "https://www.openml.org/search?type=data&id=40945",
   "version": "1",
-  "distribution": {
-    "@type": "sc:FileObject",
-    "name": "Titanic.arff",
-    "contentUrl": "https://api.openml.org/data/v1/download/16826755/Titanic.arff",
-    "encodingFormat": "text/plain",
-    "md5": "60ac7205eee0ba5045c90b3bba95b1c4"
-  },
+  "distribution": [
+    {
+      "@type": "sc:FileObject",
+      "name": "Titanic.arff",
+      "contentUrl": "https://api.openml.org/data/v1/download/16826755/Titanic.arff",
+      "encodingFormat": "text/plain",
+      "md5": "60ac7205eee0ba5045c90b3bba95b1c4"
+    }
+  ],
   "recordSet": [
     {
       "@type": "ml:RecordSet",

--- a/datasets/wiki-text/metadata.json
+++ b/datasets/wiki-text/metadata.json
@@ -10,7 +10,7 @@
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
-    "field": "ml:Field",
+    "field": "ml:field",
     "format": "ml:format",
     "includes": "ml:includes",
     "inlineData": {
@@ -18,14 +18,14 @@
       "@type": "@json"
     },
     "ml": "http://mlcommons.org/schema/",
-    "recordSet": "ml:RecordSet",
+    "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
     "replace": "ml:replace",
     "sc": "https://schema.org/",
     "separator": "ml:separator",
     "source": "ml:source",
-    "subField": "ml:SubField",
+    "subField": "ml:subField",
     "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",

--- a/python/ml_croissant/ml_croissant/_src/core/constants.py
+++ b/python/ml_croissant/ml_croissant/_src/core/constants.py
@@ -12,16 +12,18 @@ ML_COMMONS_DATA = ML_COMMONS.data
 ML_COMMONS_DATA_TYPE = ML_COMMONS.dataType
 # ML_COMMONS.format is understood as the `format` method on the class Namespace.
 ML_COMMONS_FORMAT = term.URIRef("http://mlcommons.org/schema/format")
-ML_COMMONS_FIELD = ML_COMMONS.Field
+ML_COMMONS_FIELD = ML_COMMONS.field
+ML_COMMONS_FIELD_TYPE = ML_COMMONS.Field
 ML_COMMONS_INCLUDES = ML_COMMONS.includes
-ML_COMMONS_RECORD_SET = ML_COMMONS.RecordSet
+ML_COMMONS_RECORD_SET = ML_COMMONS.recordSet
+ML_COMMONS_RECORD_SET_TYPE = ML_COMMONS.RecordSet
 ML_COMMONS_REFERENCES = ML_COMMONS.references
 ML_COMMONS_REGEX = ML_COMMONS.regex
 # ML_COMMONS.replace is understood as the `replace` method on the class Namespace.
 ML_COMMONS_REPLACE = term.URIRef("http://mlcommons.org/schema/replace")
 ML_COMMONS_SEPARATOR = ML_COMMONS.separator
 ML_COMMONS_SOURCE = ML_COMMONS.source
-ML_COMMONS_SUB_FIELD = ML_COMMONS.SubField
+ML_COMMONS_SUB_FIELD = ML_COMMONS.subField
 
 # RDF standard URIs.
 # For "@type" key:

--- a/python/ml_croissant/ml_croissant/_src/core/json_ld.py
+++ b/python/ml_croissant/ml_croissant/_src/core/json_ld.py
@@ -29,6 +29,7 @@ _KEYS_WITH_LIST = {
     constants.ML_COMMONS_FIELD,
     constants.ML_COMMONS_RECORD_SET,
     constants.ML_COMMONS_SUB_FIELD,
+    constants.SCHEMA_ORG_DISTRIBUTION,
 }
 
 
@@ -38,19 +39,19 @@ def _make_context():
         "applyTransform": "ml:applyTransform",
         "data": {"@id": "ml:data", "@nest": "source"},
         "dataType": {"@id": "ml:dataType", "@type": "@vocab"},
-        "field": "ml:Field",
+        "field": "ml:field",
         "format": "ml:format",
         "includes": "ml:includes",
         "inlineData": {"@id": "ml:data", "@type": "@json"},
         "ml": "http://mlcommons.org/schema/",
-        "recordSet": "ml:RecordSet",
+        "recordSet": "ml:recordSet",
         "references": "ml:references",
         "regex": "ml:regex",
         "replace": "ml:replace",
         "sc": "https://schema.org/",
         "separator": "ml:separator",
         "source": "ml:source",
-        "subField": "ml:SubField",
+        "subField": "ml:subField",
         "wd": "https://www.wikidata.org/wiki/",
     }
 
@@ -137,10 +138,11 @@ def expand_json_ld(data: Json) -> Json:
     # `graph.serialize` outputs a stringified list of JSON-LD nodes.
     nodes = graph.serialize(format="json-ld")
     nodes = json.loads(nodes)
+    assert nodes, "Found no node in graph"
     # Find the entry node (schema.org/Dataset).
-    entry_node = next((record for record in nodes if _is_dataset_node(record)), None)
-    if entry_node is None:
-        raise ValueError(f"File does not define {constants.SCHEMA_ORG_DATASET}.")
+    entry_node = next(
+        (record for record in nodes if _is_dataset_node(record)), nodes[0]
+    )
     id_to_node: dict[str, Json] = {}
     for node in nodes:
         node_id = node.get("@id")

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/base_node.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/base_node.py
@@ -59,6 +59,7 @@ class Node(abc.ABC):
         """
         for mandatory_property in mandatory_properties:
             value = getattr(self, mandatory_property)
+            print(self, mandatory_property, value)
             if not value:
                 error = (
                     f'Property "{constants.FROM_CROISSANT.get(mandatory_property)}" is'

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/graph.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/graph.py
@@ -146,8 +146,8 @@ def _parse_node(
         constants.SCHEMA_ORG_DATASET: Metadata,
         constants.SCHEMA_ORG_FILE_OBJECT: FileObject,
         constants.SCHEMA_ORG_FILE_SET: FileSet,
-        constants.ML_COMMONS_FIELD: Field,
-        constants.ML_COMMONS_RECORD_SET: RecordSet,
+        constants.ML_COMMONS_FIELD_TYPE: Field,
+        constants.ML_COMMONS_RECORD_SET_TYPE: RecordSet,
     }
     if node_type not in rdf_to_croissant:
         # TODO(marcenacp): Propagate the context here.
@@ -244,7 +244,7 @@ def from_rdf_to_nodes(
         issues=issues,
         rdf_graph=rdf_graph,
         expected_property=constants.ML_COMMONS_RECORD_SET,
-        expected_types=(constants.ML_COMMONS_RECORD_SET,),
+        expected_types=(constants.ML_COMMONS_RECORD_SET_TYPE,),
         folder=folder,
         graph=graph,
         parents=(metadata,),
@@ -259,7 +259,7 @@ def from_rdf_to_nodes(
             issues=issues,
             rdf_graph=rdf_graph,
             expected_property=constants.ML_COMMONS_FIELD,
-            expected_types=(constants.ML_COMMONS_FIELD,),
+            expected_types=(constants.ML_COMMONS_FIELD_TYPE,),
             folder=folder,
             graph=graph,
             parents=(metadata, record_set),
@@ -270,7 +270,7 @@ def from_rdf_to_nodes(
                 issues=issues,
                 rdf_graph=rdf_graph,
                 expected_property=constants.ML_COMMONS_SUB_FIELD,
-                expected_types=(constants.ML_COMMONS_FIELD,),
+                expected_types=(constants.ML_COMMONS_FIELD_TYPE,),
                 folder=folder,
                 graph=graph,
                 parents=(metadata, record_set, field),

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_bad_contained_in.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_bad_contained_in.json
@@ -1,36 +1,48 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
-      "name": "a-csv-table",
       "@type": "sc:FileObject",
+      "name": "a-csv-table",
       "containedIn": "#{THISDOESNOTEXIST}",
       "contentUrl": "ratings.csv",
       "encodingFormat": "text/csv",
       "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
-  ],
-  "recordSet": []
+  ]
 }

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_bad_type.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_bad_type.json
@@ -1,36 +1,48 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
-      "@type": "WRONG_TYPE_HERE",
+      "@type": "sc:WRONG_TYPE_HERE",
       "name": "a-csv-table",
-      "contentUrl": "https://www.google.com/data.csv",
       "contentSize": "117743 B",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
-      "encodingFormat": "text/csv"
+      "contentUrl": "https://www.google.com/data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
-  ],
-  "recordSet": []
+  ]
 }

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_missing_name.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_missing_name.json
@@ -1,27 +1,40 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
       "@type": "sc:FileObject",
@@ -29,6 +42,5 @@
       "encodingFormat": "text/csv",
       "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
-  ],
-  "recordSet": []
+  ]
 }

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_missing_property_content_url.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_missing_property_content_url.json
@@ -1,35 +1,47 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
       "@type": "sc:FileObject",
       "name": "a-csv-table",
       "contentSize": "117743 B",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
-      "encodingFormat": "text/csv"
+      "encodingFormat": "text/csv",
+      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
-  ],
-  "recordSet": []
+  ]
 }

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/metadata_bad_type.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/metadata_bad_type.json
@@ -1,27 +1,38 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "WRONG_TYPE",
-  "@language": "en",
+  "@type": "sc:WRONG_TYPE",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
-  "distribution": [],
-  "recordSet": []
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset"
 }

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/metadata_missing_property_name.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/metadata_missing_property_name.json
@@ -1,26 +1,37 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
   "@type": "sc:Dataset",
-  "@language": "en",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
-  "distribution": [],
-  "recordSet": []
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset"
 }

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_bad_source.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_bad_source.json
@@ -1,35 +1,48 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
       "@type": "sc:FileObject",
       "name": "a-csv-table",
-      "contentUrl": "https://www.google.com/data.csv",
       "contentSize": "117743 B",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
-      "encodingFormat": "text/csv"
+      "contentUrl": "https://www.google.com/data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
   ],
   "recordSet": [
@@ -39,8 +52,8 @@
       "description": "This is a record set.",
       "field": [
         {
-          "name": "first-field",
           "@type": "ml:Field",
+          "name": "first-field",
           "dataType": "sc:Integer",
           "source": "#{THISDOESNOTEXIST#field}"
         }

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_bad_type.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_bad_type.json
@@ -1,35 +1,48 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
       "@type": "sc:FileObject",
       "name": "a-csv-table",
-      "contentUrl": "https://www.google.com/data.csv",
       "contentSize": "117743 B",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
-      "encodingFormat": "text/csv"
+      "contentUrl": "https://www.google.com/data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
   ],
   "recordSet": [
@@ -39,8 +52,8 @@
       "description": "This is a record set.",
       "field": [
         {
+          "@type": "sc:WRONG_TYPE",
           "name": "first-field",
-          "@type": "WRONG_TYPE",
           "dataType": "sc:Integer"
         }
       ]

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_missing_property_name.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_missing_property_name.json
@@ -1,35 +1,48 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
       "@type": "sc:FileObject",
       "name": "a-csv-table",
-      "contentUrl": "https://www.google.com/data.csv",
       "contentSize": "117743 B",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
-      "encodingFormat": "text/csv"
+      "contentUrl": "https://www.google.com/data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
   ],
   "recordSet": [

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_missing_source.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_missing_source.json
@@ -1,34 +1,47 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
       "@type": "sc:FileObject",
       "name": "a-csv-table",
-      "contentUrl": "https://www.google.com/data.csv",
       "contentSize": "117743 B",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
-      "encodingFormat": "text/csv"
+      "contentUrl": "https://www.google.com/data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
   ],
   "recordSet": [
@@ -38,8 +51,8 @@
       "description": "This is a record set.",
       "field": [
         {
-          "name": "first-field",
           "@type": "ml:Field",
+          "name": "first-field",
           "dataType": "sc:Integer",
           "source": "#{a-csv-table/field}"
         }

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_bad_type.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_bad_type.json
@@ -1,46 +1,59 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
       "@type": "sc:FileObject",
       "name": "a-csv-table",
-      "contentUrl": "https://www.google.com/data.csv",
       "contentSize": "117743 B",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
-      "encodingFormat": "text/csv"
+      "contentUrl": "https://www.google.com/data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
   ],
   "recordSet": [
     {
-      "@type": "WRONG_TYPE",
+      "@type": "sc:WRONG_TYPE",
       "name": "a-record-set",
       "description": "This is a record set.",
       "field": [
         {
-          "name": "first-field",
           "@type": "ml:Field",
+          "name": "first-field",
           "dataType": "sc:Integer"
         }
       ]

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_missing_context_for_datatype.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_missing_context_for_datatype.json
@@ -1,34 +1,44 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
       "@type": "sc:FileObject",
       "name": "a-csv-table",
-      "contentUrl": "https://www.google.com/data.csv",
       "contentSize": "117743 B",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
-      "encodingFormat": "text/csv"
+      "contentUrl": "https://www.google.com/data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
   ],
   "recordSet": [
@@ -38,8 +48,8 @@
       "description": "This is a record set.",
       "field": [
         {
-          "name": "first-field",
           "@type": "ml:Field",
+          "name": "first-field",
           "dataType": "sc:Integer",
           "source": "#{a-csv-table/column}"
         }

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_missing_property_name.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_missing_property_name.json
@@ -1,35 +1,48 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
       "@type": "sc:FileObject",
       "name": "a-csv-table",
-      "contentUrl": "https://www.google.com/data.csv",
       "contentSize": "117743 B",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
-      "encodingFormat": "text/csv"
+      "contentUrl": "https://www.google.com/data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
   ],
   "recordSet": [
@@ -38,8 +51,8 @@
       "description": "This is a record set.",
       "field": [
         {
-          "name": "first-field",
           "@type": "ml:Field",
+          "name": "first-field",
           "dataType": "sc:Integer"
         }
       ]

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/valid.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/valid.json
@@ -1,35 +1,48 @@
 {
   "@context": {
     "@vocab": "https://schema.org/",
-    "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/",
-    "includes": "ml:includes",
-    "recordSet": "ml:RecordSet",
-    "field": "ml:Field",
-    "subField": "ml:SubField",
-    "dataType": "ml:dataType",
-    "source": "ml:source",
-    "data": "ml:data",
     "applyTransform": "ml:applyTransform",
+    "data": {
+      "@id": "ml:data",
+      "@nest": "source"
+    },
+    "dataType": {
+      "@id": "ml:dataType",
+      "@type": "@vocab"
+    },
+    "field": "ml:field",
     "format": "ml:format",
+    "includes": "ml:includes",
+    "inlineData": {
+      "@id": "ml:data",
+      "@type": "@json"
+    },
+    "ml": "http://mlcommons.org/schema/",
+    "recordSet": "ml:recordSet",
+    "references": "ml:references",
     "regex": "ml:regex",
-    "separator": "ml:separator"
+    "replace": "ml:replace",
+    "sc": "https://schema.org/",
+    "separator": "ml:separator",
+    "source": "ml:source",
+    "subField": "ml:subField",
+    "wd": "https://www.wikidata.org/wiki/"
   },
-  "@type": "Dataset",
-  "@language": "en",
+  "@type": "sc:Dataset",
   "name": "mydataset",
-  "url": "https://www.google.com/dataset",
   "description": "This is a description.",
-  "license": "This is a license.",
+  "@language": "en",
   "citation": "This is a citation.",
+  "license": "This is a license.",
+  "url": "https://www.google.com/dataset",
   "distribution": [
     {
       "@type": "sc:FileObject",
       "name": "a-csv-table",
-      "contentUrl": "https://www.google.com/data.csv",
       "contentSize": "117743 B",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
-      "encodingFormat": "text/csv"
+      "contentUrl": "https://www.google.com/data.csv",
+      "encodingFormat": "text/csv",
+      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
     }
   ],
   "recordSet": [
@@ -39,8 +52,8 @@
       "description": "This is a record set.",
       "field": [
         {
-          "name": "first-field",
           "@type": "ml:Field",
+          "name": "first-field",
           "dataType": "sc:Integer"
         }
       ]

--- a/python/ml_croissant/scripts/migrations/migrate.py
+++ b/python/ml_croissant/scripts/migrations/migrate.py
@@ -10,13 +10,23 @@ from etils import epath
 from ml_croissant._src.core.json_ld import expand_json_ld, compact_json_ld
 
 if __name__ == "__main__":
+    # Datasets in croissant/datasets
     datasets = [path for path in epath.Path("../../datasets").glob("*/*.json")]
+    # Datasets in croissant/python/ml_croissant/_src/tests
+    datasets += [
+        path for path in epath.Path("ml_croissant/_src/tests/graphs").glob("*.json")
+    ]
     for dataset in datasets:
         print(f"Converting {dataset}...")
         with dataset.open("r") as f:
             json_ld = json.load(f)
             json_ld = compact_json_ld(expand_json_ld(json_ld))
         with dataset.open("w") as f:
+            # Special cases for test datasets without @context
+            if dataset.name == "recordset_missing_context_for_datatype.json":
+                del json_ld["@context"]["dataType"]
+            if dataset.name == "mlfield_missing_source.json":
+                del json_ld["@context"]["source"]
             json.dump(json_ld, f, indent="  ")
             f.write("\n")
     print("Done.")


### PR DESCRIPTION
When speaking to @benjelloun, I realized we mixed attributes and types when manipulating RecordSets, etc.

In this PR:
- I fix the usage of: `ml:recordSet`/`ml:RecordSet`, `ml:field`/`ml:Field`, `ml:subField`.
- I auto-generate JSON-LD test files, so that they have the proper `@context`.