### PR TITLE
Rename `inlineData`->`data`

### DIFF
--- a/datasets/birds/birds_by_openml_converter.json
+++ b/datasets/birds/birds_by_openml_converter.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/coco2014-mini/metadata.json
+++ b/datasets/coco2014-mini/metadata.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",
@@ -80,7 +76,7 @@
           ]
         }
       ],
-      "inlineData": [
+      "data": [
         {
           "name": "train",
           "url": "https://mlcommons.org/definitions/training_split"

--- a/datasets/coco2014-mini/metadata.json
+++ b/datasets/coco2014-mini/metadata.json
@@ -52,7 +52,7 @@
     {
       "@type": "sc:FileSet",
       "name": "image-files",
-      "containedIn": "#{train2014.zip}",
+      "containedIn": "train2014.zip",
       "encodingFormat": "image/jpeg",
       "includes": "*.jpg"
     }

--- a/datasets/coco2014/metadata.json
+++ b/datasets/coco2014/metadata.json
@@ -72,9 +72,9 @@
       "@type": "sc:FileSet",
       "name": "image-files",
       "containedIn": [
-        "#{train2014.zip}",
-        "#{val2014.zip}",
-        "#{test2014.zip}"
+        "train2014.zip",
+        "val2014.zip",
+        "test2014.zip"
       ],
       "encodingFormat": "image/jpeg",
       "includes": "*.jpg"
@@ -90,21 +90,21 @@
     {
       "@type": "sc:FileSet",
       "name": "caption_annotations-files",
-      "containedIn": "#{annotations_trainval2014.zip}",
+      "containedIn": "annotations_trainval2014.zip",
       "encodingFormat": "application/json",
       "includes": "annotations/captions_(val|train)2014.json"
     },
     {
       "@type": "sc:FileSet",
       "name": "person_keypoints_annotations",
-      "containedIn": "#{annotations_trainval2014.zip}",
+      "containedIn": "annotations_trainval2014.zip",
       "encodingFormat": "application/json",
       "includes": "annotations/person_keypoints_(val|train)2014.json"
     },
     {
       "@type": "sc:FileSet",
       "name": "instancesperson_keypoints_annotations",
-      "containedIn": "#{annotations_trainval2014.zip}",
+      "containedIn": "annotations_trainval2014.zip",
       "encodingFormat": "application/json",
       "includes": "annotations/instances_(val|train)2014.json"
     },
@@ -119,7 +119,7 @@
     {
       "@type": "sc:FileSet",
       "name": "imageinfo",
-      "containedIn": "#{image_info_test2014.zip}",
+      "containedIn": "image_info_test2014.zip",
       "encodingFormat": "application/json",
       "includes": "annotations/image_info_test.json"
     }

--- a/datasets/coco2014/metadata.json
+++ b/datasets/coco2014/metadata.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",
@@ -147,7 +143,7 @@
           ]
         }
       ],
-      "inlineData": [
+      "data": [
         {
           "name": "train",
           "url": "https://mlcommons.org/definitions/training_split"

--- a/datasets/movielens/metadata.json
+++ b/datasets/movielens/metadata.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/movielens/metadata.json
+++ b/datasets/movielens/metadata.json
@@ -49,42 +49,42 @@
     {
       "@type": "sc:FileObject",
       "name": "ratings-table",
-      "containedIn": "#{ml-25m-archive}",
+      "containedIn": "ml-25m-archive",
       "contentUrl": "ratings.csv",
       "encodingFormat": "text/csv"
     },
     {
       "@type": "sc:FileObject",
       "name": "movies-table",
-      "containedIn": "#{ml-25m-archive}",
+      "containedIn": "ml-25m-archive",
       "contentUrl": "movies.csv",
       "encodingFormat": "text/csv"
     },
     {
       "@type": "sc:FileObject",
       "name": "tags-table",
-      "containedIn": "#{ml-25m-archive}",
+      "containedIn": "ml-25m-archive",
       "contentUrl": "tags.csv",
       "encodingFormat": "text/csv"
     },
     {
       "@type": "sc:FileObject",
       "name": "links-table",
-      "containedIn": "#{ml-25m-archive}",
+      "containedIn": "ml-25m-archive",
       "contentUrl": "links.csv",
       "encodingFormat": "text/csv"
     },
     {
       "@type": "sc:FileObject",
       "name": "genome-scores-table",
-      "containedIn": "#{ml-25m-archive}",
+      "containedIn": "ml-25m-archive",
       "contentUrl": "genome-scores.csv",
       "encodingFormat": "text/csv"
     },
     {
       "@type": "sc:FileObject",
       "name": "genome-tags-table",
-      "containedIn": "#{ml-25m-archive}",
+      "containedIn": "ml-25m-archive",
       "contentUrl": "genome-tags.csv",
       "encodingFormat": "text/csv"
     }

--- a/datasets/pass-mini/metadata.json
+++ b/datasets/pass-mini/metadata.json
@@ -66,8 +66,8 @@
       "@type": "sc:FileSet",
       "name": "image-files",
       "containedIn": [
-        "#{pass0}",
-        "#{pass1}"
+        "pass0",
+        "pass1"
       ],
       "encodingFormat": "image/jpeg",
       "includes": "*.jpg"

--- a/datasets/pass-mini/metadata.json
+++ b/datasets/pass-mini/metadata.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/pass/metadata.json
+++ b/datasets/pass/metadata.json
@@ -122,16 +122,16 @@
       "@type": "sc:FileSet",
       "name": "image-files",
       "containedIn": [
-        "#{pass0}",
-        "#{pass1}",
-        "#{pass2}",
-        "#{pass3}",
-        "#{pass4}",
-        "#{pass5}",
-        "#{pass6}",
-        "#{pass7}",
-        "#{pass8}",
-        "#{pass9}"
+        "pass0",
+        "pass1",
+        "pass2",
+        "pass3",
+        "pass4",
+        "pass5",
+        "pass6",
+        "pass7",
+        "pass8",
+        "pass9"
       ],
       "encodingFormat": "image/jpeg",
       "includes": "*.jpg"

--- a/datasets/pass/metadata.json
+++ b/datasets/pass/metadata.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/recipes/compressed_archive.json
+++ b/datasets/recipes/compressed_archive.json
@@ -48,7 +48,7 @@
     {
       "@type": "sc:FileSet",
       "name": "image-files",
-      "containedIn": "#{compressed_archive.zip}",
+      "containedIn": "compressed_archive.zip",
       "encodingFormat": "image/jpeg",
       "includes": "*.jpeg"
     }

--- a/datasets/recipes/compressed_archive.json
+++ b/datasets/recipes/compressed_archive.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/recipes/enum.json
+++ b/datasets/recipes/enum.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/recipes/minimal.json
+++ b/datasets/recipes/minimal.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/recipes/minimal_recommended.json
+++ b/datasets/recipes/minimal_recommended.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/recipes/simple-split.json
+++ b/datasets/recipes/simple-split.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/simple-dataset/metadata.json
+++ b/datasets/simple-dataset/metadata.json
@@ -58,7 +58,7 @@
     {
       "@type": "sc:FileSet",
       "name": "image-files",
-      "containedIn": "#{pass9}",
+      "containedIn": "pass9",
       "encodingFormat": "image/jpeg",
       "includes": "*.jpg"
     }

--- a/datasets/simple-dataset/metadata.json
+++ b/datasets/simple-dataset/metadata.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/simple-join/metadata.json
+++ b/datasets/simple-join/metadata.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",
@@ -67,7 +63,7 @@
           "dataType": "sc:Text"
         }
       ],
-      "inlineData": [
+      "data": [
         {
           "email": "john.smith@gmail.com",
           "fullname": "John Smith"

--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/titanic/titanic_by_openml_converter.json
+++ b/datasets/titanic/titanic_by_openml_converter.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/datasets/wiki-text/metadata.json
+++ b/datasets/wiki-text/metadata.json
@@ -51,7 +51,7 @@
     {
       "@type": "sc:FileSet",
       "name": "token-files",
-      "containedIn": "#{wikitext-103-v1.zip}",
+      "containedIn": "wikitext-103-v1.zip",
       "encodingFormat": "image/jpeg",
       "includes": "wikitext-103/*.tokens"
     },

--- a/datasets/wiki-text/metadata.json
+++ b/datasets/wiki-text/metadata.json
@@ -5,7 +5,7 @@
     "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
     "dataExtraction": "ml:dataExtraction",
     "dataType": {
@@ -16,10 +16,6 @@
     "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
     "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
     "path": "ml:path",

--- a/python/ml_croissant/ml_croissant/_src/core/json_ld.py
+++ b/python/ml_croissant/ml_croissant/_src/core/json_ld.py
@@ -38,14 +38,13 @@ def _make_context():
         "@vocab": "https://schema.org/",
         "applyTransform": "ml:applyTransform",
         "csvColumn": "ml:csvColumn",
-        "data": {"@id": "ml:data", "@nest": "source"},
+        "data": {"@id": "ml:data", "@type": "@json"},
         "dataExtraction": "ml:dataExtraction",
         "dataType": {"@id": "ml:dataType", "@type": "@vocab"},
         "field": "ml:field",
         "fileProperty": "ml:fileProperty",
         "format": "ml:format",
         "includes": "ml:includes",
-        "inlineData": {"@id": "ml:data", "@type": "@json"},
         "jsonPath": "ml:jsonPath",
         "ml": "http://mlcommons.org/schema/",
         "path": "ml:path",
@@ -74,7 +73,7 @@ def _sort_items(jsonld: Json) -> list[tuple[str, Any]]:
     """
     items = sorted(jsonld.items())
     start_keys = ["@context", "@type", "name", "description"]
-    end_keys = ["distribution", "field", "inlineData", "recordSet", "subField"]
+    end_keys = ["distribution", "field", "data", "recordSet", "subField"]
     sorted_items = []
     for key in start_keys:
         if key in jsonld:
@@ -192,7 +191,7 @@ def compact_json_ld(json: Any) -> Any:
             del json[key]
             # Data can either be inline JSON data...
             if isinstance(value, (dict, list)):
-                json["inlineData"] = value
+                json["data"] = value
             # ...or "source.data":
             else:
                 json["data"] = value

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/graph.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/graph.py
@@ -35,7 +35,6 @@ from ml_croissant._src.structure_graph.nodes import (
     RecordSet,
     Source,
 )
-from ml_croissant._src.structure_graph.nodes.source import parse_reference
 import networkx as nx
 import rdflib
 from rdflib import term
@@ -121,15 +120,10 @@ def _parse_node_params(
     references_field = constants.TO_CROISSANT[constants.ML_COMMONS_REFERENCES]
     if (references := node_params.get(references_field)) is not None:
         node_params[references_field] = Source.from_json_ld(issues, references)
-    # Parse `contained_in`.
+    # Parse `contained_in` as a tuple of str.
     contained_in_field = constants.TO_CROISSANT[constants.SCHEMA_ORG_CONTAINED_IN]
     if (contained_in := node_params.get(contained_in_field)) is not None:
-        if isinstance(contained_in, str):
-            node_params[contained_in_field] = parse_reference(issues, contained_in)
-        else:
-            node_params[contained_in_field] = (
-                parse_reference(issues, reference)[0] for reference in contained_in
-            )
+        node_params[contained_in_field] = tuple(str(uid) for uid in contained_in)
     return node_params
 
 

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/source.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/source.py
@@ -11,24 +11,6 @@ from typing import Any
 
 from ml_croissant._src.core import constants
 from ml_croissant._src.core.issues import Issues
-from ml_croissant._src.structure_graph.base_node import ID_REGEX, validate_name
-
-
-def parse_reference(issues: Issues, source_data: str) -> tuple[str, ...]:
-    """Parses a reference from a string called `source_data`."""
-    source_regex = re.compile(rf"^\#\{{({ID_REGEX})(?:\/([^\/]+))*\}}$")
-    match = source_regex.match(source_data)
-    if match is None:
-        issues.add_error(
-            f"Malformed source data: {source_data}. The source data should be written"
-            " as `#{name}` where name is valid ID."
-        )
-        return ()
-    groups = tuple(group for group in match.groups() if group is not None)
-    # Only validate the root group, because others can point to external columns
-    # (like in a CSV) with fuzzy names.
-    validate_name(issues, groups[0])
-    return groups
 
 
 class FileProperty(enum.Enum):

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/source_test.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/source_test.py
@@ -5,6 +5,7 @@ from ml_croissant._src.structure_graph.nodes.source import (
     apply_transforms_fn,
     Extract,
     FileProperty,
+    is_file_property,
     Source,
     Transform,
 )
@@ -176,3 +177,11 @@ def test_apply_transforms_fn(value, source, expected_value):
 )
 def test_get_field(source: Source, expected_field: str):
     assert source.get_field() == expected_field
+
+
+def test_is_file_property():
+    assert is_file_property("content")
+    assert is_file_property("filename")
+    assert is_file_property("filepath")
+    assert is_file_property("fullpath")
+    assert not is_file_property("foo")

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_bad_contained_in.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_bad_contained_in.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_bad_contained_in.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_bad_contained_in.json
@@ -39,7 +39,7 @@
     {
       "@type": "sc:FileObject",
       "name": "a-csv-table",
-      "containedIn": "#{THISDOESNOTEXIST}",
+      "containedIn": "THISDOESNOTEXIST",
       "contentUrl": "ratings.csv",
       "encodingFormat": "text/csv",
       "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_bad_type.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_bad_type.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_missing_name.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_missing_name.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_missing_property_content_url.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/distribution_missing_property_content_url.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/metadata_bad_type.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/metadata_bad_type.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/metadata_missing_property_name.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/metadata_missing_property_name.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_bad_source.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_bad_source.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_bad_type.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_bad_type.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_missing_property_name.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_missing_property_name.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_missing_source.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/mlfield_missing_source.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_bad_type.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_bad_type.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",
@@ -50,19 +51,17 @@
       "@type": "sc:WRONG_TYPE",
       "name": "a-record-set",
       "description": "This is a record set.",
-      "field": [
-        {
-          "@type": "ml:Field",
-          "name": "first-field",
-          "dataType": "sc:Integer",
-          "source": {
-            "dataExtraction": {
-              "csvColumn": "a-column"
-            },
-            "distribution": "a-csv-table"
-          }
+      "field": {
+        "@type": "ml:Field",
+        "name": "first-field",
+        "dataType": "sc:Integer",
+        "source": {
+          "dataExtraction": {
+            "csvColumn": "a-column"
+          },
+          "distribution": "a-csv-table"
         }
-      ]
+      }
     }
   ]
 }

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_missing_context_for_datatype.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_missing_context_for_datatype.json
@@ -2,18 +2,19 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
-      "@id": "ml:data",
-      "@nest": "source"
-    },
-    "field": "ml:field",
-    "format": "ml:format",
-    "includes": "ml:includes",
-    "inlineData": {
       "@id": "ml:data",
       "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
+    "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
+    "format": "ml:format",
+    "includes": "ml:includes",
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_missing_property_name.json
+++ b/python/ml_croissant/ml_croissant/_src/tests/graphs/recordset_missing_property_name.json
@@ -2,22 +2,23 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "applyTransform": "ml:applyTransform",
+    "csvColumn": "ml:csvColumn",
     "data": {
       "@id": "ml:data",
-      "@nest": "source"
+      "@type": "@json"
     },
+    "dataExtraction": "ml:dataExtraction",
     "dataType": {
       "@id": "ml:dataType",
       "@type": "@vocab"
     },
     "field": "ml:field",
+    "fileProperty": "ml:fileProperty",
     "format": "ml:format",
     "includes": "ml:includes",
-    "inlineData": {
-      "@id": "ml:data",
-      "@type": "@json"
-    },
+    "jsonPath": "ml:jsonPath",
     "ml": "http://mlcommons.org/schema/",
+    "path": "ml:path",
     "recordSet": "ml:recordSet",
     "references": "ml:references",
     "regex": "ml:regex",

--- a/python/ml_croissant/pyproject.toml
+++ b/python/ml_croissant/pyproject.toml
@@ -31,3 +31,6 @@ line-length = 88
 
 [tool.pytype]
 inputs = ["."]
+# PyLint is skipped for migrations as migrations are supposed to be launched on
+# fixed previous versions of the code.
+exclude = ["*/migrations/previous/*"]

--- a/python/ml_croissant/scripts/migrations/previous/202307171508.py
+++ b/python/ml_croissant/scripts/migrations/previous/202307171508.py
@@ -1,9 +1,4 @@
-# pytype: skip-file
-"""Migrations for source: https://github.com/mlcommons/croissant/issues/115.
-
-PyLint is skipped for this file as the migration is supposed to be launched on a
-fixed version of the code.
-"""
+"""Migrations for source: https://github.com/mlcommons/croissant/issues/115."""
 
 from typing import Any
 

--- a/python/ml_croissant/scripts/migrations/previous/202307201041.py
+++ b/python/ml_croissant/scripts/migrations/previous/202307201041.py
@@ -1,4 +1,3 @@
-# pytype: skip-file
 """Migrations for containedIn: https://github.com/mlcommons/croissant/issues/115."""
 
 

--- a/python/ml_croissant/scripts/migrations/previous/202307201041.py
+++ b/python/ml_croissant/scripts/migrations/previous/202307201041.py
@@ -1,0 +1,26 @@
+# pytype: skip-file
+"""Migrations for containedIn: https://github.com/mlcommons/croissant/issues/115."""
+
+
+def _migrate_contained_in(contained_in: str | list[str]):
+    if isinstance(contained_in, list):
+        return [_migrate_contained_in(el) for el in contained_in]
+    elif isinstance(contained_in, str):
+        assert contained_in.startswith("#{")
+        assert contained_in.endswith("}")
+        return contained_in.replace("#{", "").replace("}", "")
+    else:
+        raise ValueError("Impossible case")
+
+
+def up(json_ld):
+    """Up migration that converts `containedIn` to the new format."""
+    distributions = json_ld.get("distribution", [])
+    if not isinstance(distributions, list):
+        distributions = [distributions]
+    for i, distribution in enumerate(distributions):
+        if "containedIn" not in distribution:
+            continue
+        new_contained_in = _migrate_contained_in(distribution["containedIn"])
+        json_ld["distribution"][i]["containedIn"] = new_contained_in
+    return json_ld


### PR DESCRIPTION
`inlineData` was an alias created only because `data` was ambiguous with `source.data`. Now that we removed `source.data`, we can use `inlineData` again.

Only review the last commit. All other commits are from previous PRs to facilitate future rebase.