### PR TITLE
Centralize all tests in Makefile for a better DX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,17 +33,17 @@ jobs:
       run: pip install .[dev]
 
     - name: PyTest
-      run: pytest .
+      run: make pytest
 
     - name: PyLint
-      run: pylint **/*.py
+      run: make pylint
 
     # Pyflakes can see unused imports
     - name: PyFlakes
-      run: pyflakes .
+      run: make pyflakes
 
     - name: Docstrings are defined
-      run: flake8 .
+      run: make flake8
 
   python-format:
     name: Python format
@@ -79,7 +79,7 @@ jobs:
       run: pip install absl-py etils[epath] jsonpath_rw networkx pandas pytest pytype rdflib requests tqdm
 
     - name: PyType
-      run: pytype --jobs="$(grep -c ^processor /proc/cpuinfo)" --config=./pyproject.toml
+      run: make pytype
 
   validation-test:
     name: Validation / JSON-LD Tests / Python 3.11

--- a/python/ml_croissant/Makefile
+++ b/python/ml_croissant/Makefile
@@ -1,0 +1,21 @@
+# flake8 enforces docstrings.
+flake8:
+	flake8 .
+
+pyflakes:
+	pyflakes .
+
+pylint:
+	pylint **/*.py
+
+pytest:
+	pytest .
+
+pytype:
+	pytype --jobs="$$(grep -c ^processor /proc/cpuinfo)" --config=./pyproject.toml
+
+# Launch all tests as launched on GitHub actions by order of importance.
+# - Check types (pytype).
+# - Check tests (pytest).
+# - Check linters (pylint, pyflakes, flake8).
+tests: pytype pytest pylint pyflakes flake8

--- a/python/ml_croissant/README.md
+++ b/python/ml_croissant/README.md
@@ -39,8 +39,10 @@ python scripts/load.py \
 
 ## Run tests
 
+All tests can be run from the Makefile:
+
 ```bash
-pytest .
+make tests
 ```
 
 ## Design


### PR DESCRIPTION
- Previously: to launch all tests, you would have to run them manually by entering the whole command.
- Now: to launch all tests, `make tests`.