### PR TITLE
Add Sphinx to support readthedocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Sphinx documentation
+python/ml_croissant/docs/_build
+python/ml_croissant/docs/api
+python/ml_croissant/docs/index.md

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: python/ml_croissant/docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: ./python/ml_croissant
+      extra_requirements:
+        - docs

--- a/python/ml_croissant/docs/conf.py
+++ b/python/ml_croissant/docs/conf.py
@@ -1,0 +1,26 @@
+"""Generate documentation.
+
+Usage (from the root directory):
+
+```sh
+pip install -e .[docs]
+
+sphinx-build -b html docs/ docs/_build
+```
+"""
+
+import apitree
+
+modules = [
+    apitree.ModuleInfo(
+        api="ml_croissant",
+        module_name="ml_croissant",
+        alias="ml_croissant",
+        github_url="https://github.com/mlcommons/croissant",
+    ),
+]
+
+apitree.make_project(
+    modules=modules,
+    globals=globals(),
+)

--- a/python/ml_croissant/pyproject.toml
+++ b/python/ml_croissant/pyproject.toml
@@ -26,6 +26,7 @@ readme = "README.md"
 
 [project.optional-dependencies]
 dev = ["black", "flake8-docstrings", "pyflakes", "pylint", "pytest", "pytype"]
+docs = ["ml_croissant[dev]", "sphinx-apitree[ext]"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
@nathanw-mlc I'd like to setup readthedocs. Have you already done it for other mlcommons repos? Is it possible to set up the OAuth binding as explained in https://docs.readthedocs.io/en/stable/tutorial/index.html?