### PR TITLE
Remove `Structure`/`Verifier` in profit of `Metadata`.

### DIFF
--- a/python/ml_croissant/README.md
+++ b/python/ml_croissant/README.md
@@ -37,6 +37,22 @@ python scripts/load.py \
     --num_records 10
 ```
 
+## Programmatically build JSON-LD files
+
+You can programmatically build Croissant JSON-LD files using the Python API.
+
+```python
+import ml_croissant as mlc
+metadata=mlc.nodes.Metadata(
+  name="...",
+)
+metadata.to_json()  # this returns the JSON-LD file.
+```
+
+For a full working example, refer to
+[the script to convert Hugging Face datasets to Croissant files](./scripts/from_huggingface_to_croissant.py).
+This script uses the Python API to programmatically build JSON-LD files.
+
 ## Run tests
 
 All tests can be run from the Makefile:

--- a/python/ml_croissant/ml_croissant/_src/datasets.py
+++ b/python/ml_croissant/ml_croissant/_src/datasets.py
@@ -20,28 +20,15 @@ from ml_croissant._src.structure_graph.nodes.metadata import Metadata
 
 def get_operations(issues: Issues, metadata: Metadata, debug: bool) -> OperationGraph:
     """Returns operations from the metadata."""
-    try:
-        graph = metadata.graph
-        folder = metadata.folder
-        # Print all nodes for debugging purposes.
-        if debug:
-            logging.info("Found the following nodes during static analysis.")
-            for node in graph.nodes:
-                logging.info(node)
-        # Draw the structure graph for debugging purposes.
-        if debug:
-            graphs_utils.pretty_print_graph(graph, simplify=True)
-        operations = OperationGraph.from_nodes(
-            issues=issues,
-            metadata=metadata,
-            graph=graph,
-            folder=folder,
-        )
-        operations.check_graph()
-    except Exception as exception:
-        if issues.errors:
-            raise ValidationError(issues.report()) from exception
-        raise exception
+    graph = metadata.graph
+    folder = metadata.folder
+    operations = OperationGraph.from_nodes(
+        issues=issues,
+        metadata=metadata,
+        graph=graph,
+        folder=folder,
+    )
+    operations.check_graph()
     if issues.errors:
         raise ValidationError(issues.report())
     elif issues.warnings:
@@ -68,7 +55,13 @@ class Dataset:
         """Runs the static analysis of `file`."""
         issues = Issues()
         self.metadata = Metadata.from_file(issues=issues, file=self.file)
+        # Draw the structure graph for debugging purposes.
+        if self.debug:
+            graphs_utils.pretty_print_graph(self.metadata.graph, simplify=True)
         self.operations = get_operations(issues, self.metadata, self.debug)
+        # Draw the operations graph for debugging purposes.
+        if self.debug:
+            graphs_utils.pretty_print_graph(self.operations.operations, simplify=False)
 
     def records(self, record_set: str) -> Records:
         """Accesses all records belonging to the RecordSet named `record_set`."""

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/base_node.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/base_node.py
@@ -47,9 +47,9 @@ class Node(abc.ABC):
     folder: epath.Path | None = None
     name: str = ""
     graph: nx.MultiDiGraph = dataclasses.field(
-        default_factory=nx.MultiDiGraph, compare=False
+        default_factory=nx.MultiDiGraph, compare=False, init=False
     )
-    parents: list[Node] = dataclasses.field(default_factory=list)
+    parents: list[Node] = dataclasses.field(default_factory=list, init=False)
 
     def __post_init__(self):
         """Checks for `name` (common property between all nodes)."""

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/base_node_test.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/base_node_test.py
@@ -67,10 +67,14 @@ def test_validate_name(name, expected_errors):
 
 
 def test_eq():
-    node_1_with_parent_a = create_test_node(Node, name="node1", parents=["parentA"])
-    node_1_with_parent_b = create_test_node(Node, name="node1", parents=["parentB"])
-    node_2_with_parent_a = create_test_node(Node, name="node2", parents=["parentA"])
-    node_2_with_parent_b = create_test_node(Node, name="node2", parents=["parentB"])
+    node_1_with_parent_a = create_test_node(Node, name="node1")
+    node_1_with_parent_a.parents = ["parentA"]
+    node_1_with_parent_b = create_test_node(Node, name="node1")
+    node_1_with_parent_b.parents = ["parentB"]
+    node_2_with_parent_a = create_test_node(Node, name="node2")
+    node_2_with_parent_a.parents = ["parentA"]
+    node_2_with_parent_b = create_test_node(Node, name="node2")
+    node_2_with_parent_b.parents = ["parentB"]
     assert node_1_with_parent_a == node_1_with_parent_b
     assert node_2_with_parent_a == node_2_with_parent_b
     assert node_1_with_parent_a != node_2_with_parent_a

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/graph_test.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/graph_test.py
@@ -8,7 +8,7 @@ import pytest
 from rdflib import term
 
 from ml_croissant._src.core.issues import Issues
-from ml_croissant._src.structure_graph.graph import Structure
+from ml_croissant._src.structure_graph.nodes.metadata import Metadata
 
 Literal = term.Literal
 
@@ -33,8 +33,8 @@ def test_jsonld_to_python_to_jsonld(path):
     with path.open() as f:
         json_ld = json.load(f)
     issues = Issues()
-    structure = Structure.from_file(issues, path)
-    result = structure.to_json()
+    metadata = Metadata.from_file(issues, path)
+    result = metadata.to_json()
     # `distribution` may not be in the right order:
     if "distribution" in result:
         distribution = result.pop("distribution")

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/metadata.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/metadata.py
@@ -62,8 +62,9 @@ class Metadata(Node):
         self.assert_has_optional_properties("citation", "license")
 
         # Raise exception if there are errors.
-        if self.issues.errors:
-            raise ValidationError(self.issues.report())
+        for node in self.nodes():
+            if node.issues.errors:
+                raise ValidationError(node.issues.report())
 
     def to_json(self) -> Json:
         """Converts the `Metadata` to JSON."""

--- a/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/metadata_test.py
+++ b/python/ml_croissant/ml_croissant/_src/structure_graph/nodes/metadata_test.py
@@ -3,12 +3,15 @@
 from unittest import mock
 
 from etils import epath
+import pytest
 
 from ml_croissant._src.core import constants
 from ml_croissant._src.core.issues import Context
 from ml_croissant._src.core.issues import Issues
+from ml_croissant._src.core.issues import ValidationError
 from ml_croissant._src.structure_graph.base_node import Node
 from ml_croissant._src.structure_graph.nodes.metadata import Metadata
+from ml_croissant._src.structure_graph.nodes.record_set import RecordSet
 from ml_croissant._src.tests.nodes import create_test_node
 
 
@@ -47,3 +50,14 @@ def test_from_jsonld():
         url="https://mlcommons.org",
     )
     assert not issues.errors
+
+
+def test_issues_in_metadata_are_shared_with_children():
+    with pytest.raises(ValidationError, match="is mandatory, but does not exist"):
+        Metadata(
+            name="name",
+            description="description",
+            url="https://mlcommons.org",
+            # We did not specify the RecordSet's name. Hence the exception above:
+            record_sets=[RecordSet(description="description")],
+        )

--- a/python/ml_croissant/ml_croissant/_src/tests/nodes.py
+++ b/python/ml_croissant/ml_croissant/_src/tests/nodes.py
@@ -4,7 +4,6 @@ import functools
 from typing import Callable, TypeVar
 
 from etils import epath
-import networkx as nx
 
 from ml_croissant._src.core.issues import Context
 from ml_croissant._src.core.issues import Issues
@@ -31,10 +30,8 @@ def _node_params(**kwargs):
     params = {
         "issues": Issues(),
         "context": Context(),
-        "graph": nx.MultiDiGraph(),
         "name": "node_name",
         "folder": epath.Path(),
-        "parents": [],
     }
     for key, value in kwargs.items():
         params[key] = value
@@ -53,10 +50,8 @@ def create_test_node(cls: type[T], **kwargs) -> T:
     ```python
     node = FileSet(
         issues=...,
-        graph=...,
         name=...,
         folder=...,
-        parents=...,
         description="Description"
     )
     ```

--- a/python/ml_croissant/scripts/from_huggingface_to_croissant.py
+++ b/python/ml_croissant/scripts/from_huggingface_to_croissant.py
@@ -139,9 +139,6 @@ def convert(dataset: str) -> dict[str, Any]:
             )
         ],
     )
-    # Check if there are errors:
-    if metadata.issues.errors:
-        logging.error(metadata.issues.report())
     # Serialize to JSON-LD:
     return metadata.to_json()
 


### PR DESCRIPTION
We remove both classes for two reasons:

- The Structure class is not created when we create a Metadata class programmatically.
- The Structure class is now a useless container. So we deprecate it in favor of Metadata.

Now when writing...

```python
dataset = mlc.Dataset(
  metadata=mlc.nodes.Metadata(...)
)
```

...all checks are performed like when writing `Dataset.from_file`.