### PR TITLE
Remove tracing back the package name in mlcroissant

### DIFF
--- a/python/ml_croissant/ml_croissant/_src/core/optional.py
+++ b/python/ml_croissant/ml_croissant/_src/core/optional.py
@@ -5,15 +5,6 @@ from __future__ import annotations
 import importlib
 import types
 
-from etils import epath
-import toml
-
-
-def list_optional_deps() -> dict[str, str]:
-    """Lists all optional dependencies from the pyproject.toml."""
-    toml_file = epath.Path(__file__).parent.parent.parent.parent / "pyproject.toml"
-    return toml.load(toml_file).get("project", {}).get("optional-dependencies", {})
-
 
 def _try_import(module_name: str, package_name: str | None = None):
     """Tries importing a module, with an informative error message on failure.
@@ -27,11 +18,9 @@ def _try_import(module_name: str, package_name: str | None = None):
     try:
         return importlib.import_module(module_name)
     except ImportError as exception:
-        optional_deps = list_optional_deps()
+        if package_name is None:
+            package_name = module_name
         installs = f"`pip install {package_name}`"
-        for sub_module, deps in optional_deps.items():
-            if package_name in deps:
-                installs = f"`pip install ml_croissant[{sub_module}]`"
         error = (
             f"Failed importing {module_name}. This likely means that the dataset"
             " requires additional dependencies that have to be manually installed"

--- a/python/ml_croissant/ml_croissant/_src/core/optional_test.py
+++ b/python/ml_croissant/ml_croissant/_src/core/optional_test.py
@@ -7,11 +7,6 @@ import pytest
 
 from ml_croissant._src.core.optional import _try_import
 from ml_croissant._src.core.optional import deps
-from ml_croissant._src.core.optional import list_optional_deps
-
-
-def test_list_optional_deps():
-    assert list(list_optional_deps().keys()) == ["dev", "git", "image", "parquet"]
 
 
 @pytest.mark.parametrize(
@@ -26,9 +21,7 @@ def test_load_optional_deps(optional_deps):
 
 def test_explicit_error_message():
     with mock.patch.object(importlib, "import_module", side_effect=ImportError):
-        with pytest.raises(ImportError, match="pip install ml_croissant\\[parquet\\]"):
-            _try_import("pyarrow")
         with pytest.raises(ImportError, match="pip install foo"):
             _try_import("foo")
-        with pytest.raises(ImportError, match="pip install ml_croissant\\[git\\]"):
-            _try_import("git", package_name="GitPython")
+        with pytest.raises(ImportError, match="pip install bar"):
+            _try_import("foo", package_name="bar")

--- a/python/ml_croissant/pyproject.toml
+++ b/python/ml_croissant/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   "rdflib",
   "requests",
   "tqdm",
-  "toml",
 ]
 readme = "README.md"
 


### PR DESCRIPTION
1. This removes code...
2. This won't work once the package is built and downloaded eg from PyPI...

So better simplify now.