### PR TITLE
Separating hermetic and nonhermetic tests

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/datasets_test.py
+++ b/python/mlcroissant/mlcroissant/_src/datasets_test.py
@@ -46,33 +46,7 @@ def test_static_analysis(folder):
     assert str(error_info.value) == get_error_msg(base_path / folder)
 
 
-# IF THIS TEST FAILS OR YOU ADD A NEW DATASET:
-# You can regenerate .pkl files by launching
-# ```bash
-# python scripts/load.py \
-#   --file ../../datasets/{{dataset_name}}/metadata.json \
-#   --record_set {{record_set_name}} \
-#   --update_output \
-#   --num_records -1
-# ```
-@pytest.mark.parametrize(
-    ["dataset_name", "record_set_name", "num_records"],
-    [
-        # Hermetic test cases (data from local folders).
-        ["coco2014-mini", "captions", -1],
-        ["coco2014-mini", "images", -1],
-        ["pass-mini", "images", -1],
-        ["simple-join", "publications_by_user", -1],
-        ["simple-parquet", "persons", -1],
-        # Non-hermetic test cases (data from the internet). If non-hermetic tests are
-        # not maintainable/suitable for unit tests, we can isolate them elsewhere.
-        ["gpt-3", "default", 10],
-        ["huggingface-c4", "en", 1],
-        ["huggingface-mnist", "default", 10],
-        ["titanic", "passengers", -1],
-    ],
-)
-def test_loading(dataset_name, record_set_name, num_records):
+def load_records_and_test_equality(dataset_name, record_set_name, num_records):
     print(
         "If this test fails, update JSONL with: `python scripts/load.py --file"
         f" ../../datasets/{dataset_name}/metadata.json --record_set"
@@ -99,6 +73,46 @@ def test_loading(dataset_name, record_set_name, num_records):
         assert record == expected_records[i]
         length += 1
     assert len(expected_records) == length
+
+
+# IF (NON)-HERMETIC TESTS FAIL, OR A NEW DATASET IS ADDED:
+# You can regenerate .pkl files by launching
+# ```bash
+# python scripts/load.py \
+#   --file ../../datasets/{{dataset_name}}/metadata.json \
+#   --record_set {{record_set_name}} \
+#   --update_output \
+#   --num_records -1
+# ```
+
+# Hermetic test cases (data from local folders).
+@pytest.mark.parametrize(
+    ["dataset_name", "record_set_name", "num_records"],
+    [
+        ["coco2014-mini", "captions", -1],
+        ["coco2014-mini", "images", -1],
+        ["pass-mini", "images", -1],
+        ["simple-join", "publications_by_user", -1],
+        ["simple-parquet", "persons", -1],
+    ],
+)
+def test_hermetic_loading(dataset_name, record_set_name, num_records):
+    load_records_and_test_equality(dataset_name, record_set_name, num_records)
+
+
+# Non-hermetic test cases (data from the internet).
+@pytest.mark.nonhermetic
+@pytest.mark.parametrize(
+    ["dataset_name", "record_set_name", "num_records"],
+    [
+        ["gpt-3", "default", 10],
+        ["huggingface-c4", "en", 1],
+        ["huggingface-mnist", "default", 10],
+        ["titanic", "passengers", -1],
+    ],
+)
+def test_nonhermetic_loading(dataset_name, record_set_name, num_records):
+    load_records_and_test_equality(dataset_name, record_set_name, num_records)
 
 
 def test_raises_when_the_record_set_does_not_exist():

--- a/python/mlcroissant/pyproject.toml
+++ b/python/mlcroissant/pyproject.toml
@@ -68,7 +68,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = --strict-markers
+addopts = "--strict-markers"
 markers = [
     "nonhermetic: Non-hermetic test cases (data from the internet)."
 ]

--- a/python/mlcroissant/pyproject.toml
+++ b/python/mlcroissant/pyproject.toml
@@ -68,6 +68,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
+addopts = --strict-markers
 markers = [
     "nonhermetic: Non-hermetic test cases (data from the internet)."
 ]

--- a/python/mlcroissant/pyproject.toml
+++ b/python/mlcroissant/pyproject.toml
@@ -66,3 +66,8 @@ exclude = ["recipes*"]
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+markers = [
+    "nonhermetic: Non-hermetic test cases (data from the internet)."
+]

--- a/python/mlcroissant/pyproject.toml
+++ b/python/mlcroissant/pyproject.toml
@@ -68,6 +68,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
+# Pytest settings configurations.
 addopts = "--strict-markers"
 markers = [
     "nonhermetic: Non-hermetic test cases (data from the internet)."


### PR DESCRIPTION
Certain tests are non-hermetic as they need to download data from the Internet. We separate them from hermetic tests.