### PR TITLE
Update optional.py

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/core/optional.py
+++ b/python/mlcroissant/mlcroissant/_src/core/optional.py
@@ -41,7 +41,7 @@ class cached_class_property(classmethod):
         self._func = func
         self._cache = {}
 
-    def __get__(self, obj, objtype):
+    def __get__(self, obj, objtype=None):
         """Cached getter."""
         if objtype not in self._cache:
             self._cache[objtype] = self._func(objtype)


### PR DESCRIPTION
Parameter 'objtype' must have a default value to solve signature mismatch error:

`Overriding method signature mismatch`

Base signature is:
`def builtins.classmethod.__get__(self, __obj: Optional[_T3], __type: Optional[Type[_T3]] = ...) -> Callable[[_P], _T2]`