### PR TITLE
Stricter pytype rules in pyproject.toml.

### DIFF
--- a/python/mlcroissant/pyproject.toml
+++ b/python/mlcroissant/pyproject.toml
@@ -58,6 +58,9 @@ inputs = ["."]
 # PyLint is skipped for migrations as migrations are supposed to be launched on
 # fixed previous versions of the code.
 exclude = ["*/migrations/previous/*"]
+strict_none_binding = true
+use_enum_overlay = true
+use_fiddle_overlay = true
 
 [tool.isort]
 profile = "google"


### PR DESCRIPTION
With these parameters, errors that used to not fail now fail (e.g., the errors fixed in https://github.com/mlcommons/croissant/pull/248).