### PR TITLE
Add EOF newline to introduction notebook

### DIFF
--- a/python/mlcroissant/recipes/introduction.ipynb
+++ b/python/mlcroissant/recipes/introduction.ipynb
@@ -253,7 +253,8 @@
         "  content = metadata.to_json()\n",
         "  content = json.dumps(content, indent=2)\n",
         "  print(content)\n",
-        "  f.write(content)"
+        "  f.write(content)\n",
+        "  f.write(\"\\n\")  # Terminate file with newline"
       ],
       "metadata": {
         "id": "-XCycu81ECVq"


### PR DESCRIPTION
JSON dump doesn't seem to add newline at end of file. Adding newline to prevent confusion when programmatically creating datasets.