### PR TITLE
Refactor GroupRecordSetStart/GroupRecordSetEnd.

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/datasets_test.py
+++ b/python/mlcroissant/mlcroissant/_src/datasets_test.py
@@ -51,7 +51,7 @@ def load_records_and_test_equality(dataset_name, record_set_name, num_records):
     print(
         "If this test fails, update JSONL with: `python mlcroissant/scripts/load.py"
         f" --file ../../datasets/{dataset_name} --record_set"
-        f" {record_set_name} --update_output --num_records {num_records} --debug`"
+        f" {record_set_name} --num_records {num_records} --debug --update_output`"
     )
     config = (
         epath.Path(__file__).parent.parent.parent.parent.parent

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/execute_test.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/execute_test.py
@@ -2,6 +2,8 @@
 
 from unittest import mock
 
+import pandas as pd
+
 from mlcroissant._src.operation_graph.base_operation import Operations
 from mlcroissant._src.operation_graph.execute import execute_downloads
 from mlcroissant._src.operation_graph.execute import execute_operations_sequentially
@@ -54,8 +56,11 @@ def test_only_execute_needed_operations():
 
     with mock.patch.object(Download, "__call__") as download_call, mock.patch.object(
         Data, "__call__"
-    ) as data_call:
+    ) as data_call, mock.patch.object(
+        ReadField, "__call__", return_value=pd.Series([])
+    ) as read_field_mock:
         # Use list(iterator) to actually yield all operations and execute them.
         list(execute_operations_sequentially("my-record-set", operations))
         assert download_call.call_count == 1
+        assert read_field_mock.call_count == 1
         assert data_call.call_count == 0

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field_test.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field_test.py
@@ -78,7 +78,7 @@ def test_extract_lines(separator):
         path = tempdir + "/file.txt"
         with open(path, "wb") as f:
             f.write(content)
-        series = field._extract_lines("foo", path)
+        series = field._extract_lines(path, "foo")
         expected = pd.Series(
             [b"bon jour  ", b"", b" h\xc3\xa9llo ", b"hallo "], name="foo"
         )


### PR DESCRIPTION
- Reversed the role of `GroupRecordSetStart` and `End`, so that they correspond to what hapens at the start and end of a RecordSet.
- This allowed to simplify the function `execute_operations_sequentially` that executes all the operations.
<img width="1445" alt="image" src="https://github.com/mlcommons/croissant/assets/17081356/a88e6155-fb85-4834-be75-464e045ea2f9">

- In doing so, I had to properly type the function `_extract_value` (`pd.Series`->`pd.Series`).