### PR TITLE
Add git lfs install instructions

### DIFF
--- a/python/mlcroissant/README.md
+++ b/python/mlcroissant/README.md
@@ -72,6 +72,12 @@ All tests can be run from the Makefile:
 make tests
 ```
 
+Note that `git lfs` should be installed to successfully pass all tests:
+
+```bash
+git lfs install
+```
+
 ## Design
 
 The most important modules in the library are:

--- a/python/mlcroissant/mlcroissant/_src/core/git.py
+++ b/python/mlcroissant/mlcroissant/_src/core/git.py
@@ -34,4 +34,9 @@ def download_git_lfs_file(file: Path):
     logging.info(
         "Downloading git-lfs file: %s in working dir: %s", fullpath, working_dir
     )
-    repo.execute(["git", "lfs", "pull", "--include", fullpath])
+    try:
+        repo.execute(["git", "lfs", "pull", "--include", fullpath])
+    except deps.git.exc.GitCommandError as ex:
+        if ("You called a Git command named 'lfs', which does not exist."
+                in ex.stderr):
+            raise RuntimeError("git lfs is not installed!") from ex

--- a/python/mlcroissant/mlcroissant/_src/core/git.py
+++ b/python/mlcroissant/mlcroissant/_src/core/git.py
@@ -37,6 +37,7 @@ def download_git_lfs_file(file: Path):
     try:
         repo.execute(["git", "lfs", "pull", "--include", fullpath])
     except deps.git.exc.GitCommandError as ex:
-        if ("You called a Git command named 'lfs', which does not exist."
-                in ex.stderr):
-            raise RuntimeError("git lfs is not installed!") from ex
+        raise RuntimeError("Problem when launching `git lfs`. "
+                           "Possible problems: Have you installed git lfs "
+                           f"locally? Is '{fullpath}' a valid `git lfs` "
+                           "repository?") from ex


### PR DESCRIPTION
There seems to be implicit usage of `git lfs`, which is potentially surprising and can cause flaky tests for unsuspecting users. The patch adds a check and install instructions.