### PR TITLE
Proposal: new properties `ml:annotationOfField` and `ml:format` especially useful for bounding boxes.

### DIFF
--- a/datasets/coco2014-mini/data/captions_train2014.json
+++ b/datasets/coco2014-mini/data/captions_train2014.json
@@ -93,22 +93,22 @@
     ],
     "annotations": [
         {
-            "image_id": 318556,
+            "image_id": 57870,
             "id": 48,
             "caption": "A very clean and well decorated empty bathroom"
         },
         {
-            "image_id": 116100,
+            "image_id": 384029,
             "id": 67,
             "caption": "A panoramic view of a kitchen and all of its appliances."
         },
         {
-            "image_id": 318556,
+            "image_id": 222016,
             "id": 126,
             "caption": "A blue and white bathroom with butterfly themed wall tiles."
         },
         {
-            "image_id": 116100,
+            "image_id": 520950,
             "id": 148,
             "caption": "A panoramic photo of a kitchen and dining room"
         }

--- a/datasets/coco2014-mini/metadata.json
+++ b/datasets/coco2014-mini/metadata.json
@@ -128,6 +128,21 @@
         },
         {
           "@type": "ml:Field",
+          "name": "image_id",
+          "description": "The filename of the image. eg: COCO_train2014_000000000003.jpg",
+          "dataType": "sc:Integer",
+          "source": {
+            "distribution": "image-files",
+            "extract": {
+              "fileProperty": "filename"
+            },
+            "transform": {
+              "regex": "^COCO_(?:train|val|test)2014_(\\d+)\\.jpg$"
+            }
+          }
+        },
+        {
+          "@type": "ml:Field",
           "name": "image_content",
           "description": "The content of the image.",
           "dataType": "sc:ImageObject",
@@ -247,6 +262,9 @@
           "name": "image_id",
           "description": "The ID of the image.",
           "dataType": "sc:Integer",
+          "references": {
+            "field": "images/image_id"
+          },
           "source": {
             "distribution": "bbox_annotations-files",
             "extract": {
@@ -256,8 +274,29 @@
         },
         {
           "@type": "ml:Field",
+          "name": "image_content",
+          "source": {
+            "field": "images/image_content"
+          }
+        },
+        {
+          "@type": "ml:Field",
           "name": "bbox",
           "description": "The bounding box on the image.",
+          "additionalProperty": [
+            {
+              "@type": "sc:PropertyValue",
+              "name": "annotationOfField",
+              "description": "This shows which field is annotated.",
+              "value": "image_content"
+            },
+            {
+              "@type": "sc:PropertyValue",
+              "name": "format",
+              "description": "The format of the bounding box following Keras format (https://keras.io/api/keras_cv/bounding_box/formats/).",
+              "value": "XYXY"
+            }
+          ],
           "dataType": "ml:BoundingBox",
           "source": {
             "distribution": "bbox_annotations-files",

--- a/datasets/coco2014-mini/output/captions.jsonl
+++ b/datasets/coco2014-mini/output/captions.jsonl
@@ -1,4 +1,4 @@
-{"id": 48, "image_id": 318556, "caption": "A very clean and well decorated empty bathroom", "split": "train"}
-{"id": 67, "image_id": 116100, "caption": "A panoramic view of a kitchen and all of its appliances.", "split": "train"}
-{"id": 126, "image_id": 318556, "caption": "A blue and white bathroom with butterfly themed wall tiles.", "split": "train"}
-{"id": 148, "image_id": 116100, "caption": "A panoramic photo of a kitchen and dining room", "split": "train"}
+{"id": 48, "image_id": 57870, "caption": "A very clean and well decorated empty bathroom", "split": "train"}
+{"id": 67, "image_id": 384029, "caption": "A panoramic view of a kitchen and all of its appliances.", "split": "train"}
+{"id": 126, "image_id": 222016, "caption": "A blue and white bathroom with butterfly themed wall tiles.", "split": "train"}
+{"id": 148, "image_id": 520950, "caption": "A panoramic photo of a kitchen and dining room", "split": "train"}

--- a/datasets/coco2014-mini/output/images.jsonl
+++ b/datasets/coco2014-mini/output/images.jsonl
@@ -1,2 +1,2 @@
-{"image_filename": "COCO_train2014_000000467840.jpg", "image_content": "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=3x2 at <MEMORY_ADDRESS>>", "split": "train"}
-{"image_filename": "COCO_train2014_000000533055.jpg", "image_content": "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=3x2 at <MEMORY_ADDRESS>>", "split": "train"}
+{"image_filename": "COCO_train2014_000000467840.jpg", "image_id": 467840, "image_content": "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=3x2 at <MEMORY_ADDRESS>>", "split": "train"}
+{"image_filename": "COCO_train2014_000000533055.jpg", "image_id": 533055, "image_content": "<PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=3x2 at <MEMORY_ADDRESS>>", "split": "train"}


### PR DESCRIPTION
- `ml:annotationOfField` shows the field in the ml:RecordSet that is being annotated, e.g. in this example the bounding box is the annotation for an image.
- `ml:format` is the format of the bounding box, as per [Keras bounding box format](https://keras.io/api/keras_cv/bounding_box/formats/): `XYXY`, `XYWH`, etc.

Other types (like `sc:AudioObject`) will need additional properties.