### PR TITLE
Add the 'Add manually' button for resources

### DIFF
--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -23,6 +23,10 @@ class SelectedResource:
     pass
 
 
+class AddManually:
+    pass
+
+
 @dataclasses.dataclass
 class FileObject:
     """FileObject analogue for editor"""

--- a/editor/cypress/e2e/uploadCsv.cy.js
+++ b/editor/cypress/e2e/uploadCsv.cy.js
@@ -32,7 +32,7 @@ describe('Editor loads a local CSV as a resource', () => {
       })
     })
     cy.get('.uploadedFileData').contains('base.csv')
-    cy.get('button').contains('Add').click()
+    cy.get('button').contains('Upload').click()
     // The file is uploaded, so we can click on it to see the details.
     // Waiting a few seconds to wait for the resource to download.
     cy.wait(2000)

--- a/editor/views/files.py
+++ b/editor/views/files.py
@@ -21,16 +21,20 @@ _LOCAL_FILE_KEY = "import_from_local_file"
 
 
 def render_files():
-    col1, col2 = st.columns([1, 1], gap="medium")
+    col1, col2, col3 = st.columns([1, 1, 1], gap="small")
     with col1:
-        files = st.session_state[Metadata].distribution
-        resource = _render_left_panel(files)
-        st.session_state[SelectedResource] = resource
+        st.subheader("Upload more resources")
+        _render_upload_panel()
     with col2:
+        st.subheader("Uploaded resources")
+        files = st.session_state[Metadata].distribution
+        resource = _render_resources_panel(files)
+        st.session_state[SelectedResource] = resource
+    with col3:
         _render_right_panel()
 
 
-def _render_left_panel(files: list[Resource]) -> Resource | None:
+def _render_resources_panel(files: list[Resource]) -> Resource | None:
     """Renders the left panel: the list of all resources."""
     filename_to_file: dict[str, list[Resource]] = {}
     nodes = []
@@ -47,22 +51,11 @@ def _render_left_panel(files: list[Resource]) -> Resource | None:
             parents = []
         nodes.append({"name": name, "type": type, "parents": parents})
 
-    def add_manually():
-        # Only set the state, render_files() will show the form.
-        st.session_state[AddManually] = True
-
     name = None
-    with st.container():
-        st.subheader("Uploaded resources")
-        if nodes:
-            name = render_tree(nodes, key="-".join([node["name"] for node in nodes]))
-        else:
-            st.write("No resource yet.")
-        st.button("Add manually", on_click=add_manually)
-
-    with st.container():
-        st.subheader("Upload more files")
-        _render_upload_form()
+    if nodes:
+        name = render_tree(nodes, key="-".join([node["name"] for node in nodes]))
+    else:
+        st.write("No resource yet.")
 
     if not name:
         return None
@@ -70,14 +63,45 @@ def _render_left_panel(files: list[Resource]) -> Resource | None:
     return file
 
 
-def _render_upload_form():
+def _render_upload_panel():
     """Renders the form to upload from local or upload from URL."""
     with st.form(key="upload_form", clear_on_submit=True):
         file_type_name = st.selectbox("Encoding format", options=FILE_TYPES.keys())
+        tab1, tab2, tab3 = st.tabs([
+            "Import from a local file", "Import from a URL", "Add manually"
+        ])
 
-        col1, col2 = st.columns(2)
-        col1.file_uploader("Import from a local file", key=_LOCAL_FILE_KEY)
-        col2.text_input("Import from a URL", key=_DISTANT_URL_KEY)
+        with tab1:
+            st.file_uploader("Select a file", key=_LOCAL_FILE_KEY)
+
+        with tab2:
+            st.text_input("URL:", key=_DISTANT_URL_KEY)
+
+        with tab3:
+            resource_type = st.selectbox("Type", options=["FileObject", "FileSet"])
+
+            file = FileObject() if resource_type == "FileObject" else FileSet()
+
+            name = st.text_input(
+                needed_field("File name"), value=file.name, key="manual_name"
+            )
+            description = st.text_area(
+                "File description",
+                value=file.description,
+                placeholder="Provide a clear description of the file.",
+                key="manual_description",
+            )
+            sha256 = st.text_input(
+                needed_field("SHA256"),
+                value=file.sha256,
+                disabled=True,
+                key="manual_sha256",
+            )
+            parent = st.text_input(
+                needed_field("Parent"),
+                value=file.encoding_format,
+                key="manual_parent",
+            )
 
         def handle_on_click():
             url = st.session_state[_DISTANT_URL_KEY]
@@ -92,6 +116,7 @@ def _render_upload_form():
                 file = file_from_url(file_type, url, names)
             elif uploaded_file:
                 file = file_from_upload(file_type, uploaded_file, names)
+            # todo: handle manually created resource.
             else:
                 st.toast("Please, import either a local file or a URL.", icon="❌")
                 return
@@ -107,9 +132,7 @@ def _render_upload_form():
 def _render_right_panel():
     """Renders the right panel: either a form to create a resource or details
     of the selected resource."""
-    if st.session_state.get(AddManually):
-        _render_add_manually_form()
-    elif st.session_state.get(SelectedResource):
+    if st.session_state.get(SelectedResource):
         _render_resource_details(st.session_state[SelectedResource])
 
 
@@ -160,37 +183,3 @@ def _render_resource_details(selected_file: Resource):
                 df=file.df,
             )
             st.session_state[Metadata].update_distribution(key, file)
-
-
-def _render_add_manually_form():
-    """Renders the form to add a resource manually."""
-    st.session_state[AddManually] = None
-    with st.form(key="manual_upload_form", clear_on_submit=True):
-        file_type_name = st.selectbox("Type", options=[FileObject, FileSet])
-
-        file = FileObject()
-
-        name = st.text_input(needed_field("Name"), value=file.name, key="manual_name")
-        description = st.text_area(
-            "Description",
-            value=file.description,
-            placeholder="Provide a clear description of the file.",
-            key="manual_description",
-        )
-        sha256 = st.text_input(
-            needed_field("SHA256"),
-            value=file.sha256,
-            disabled=True,
-            key="manual_sha256",
-        )
-        parent = st.text_input(
-            needed_field("Parent"),
-            value=file.encoding_format,
-            key="manual_parent",
-        )
-
-        def handle_on_click():
-            # todo: add created resource.
-            pass
-
-        st.form_submit_button("Add", on_click=handle_on_click)


### PR DESCRIPTION
Adds a "Add manually" button which creates a form with required fields for a new resource.

The user can switch between "Add manually" form and viewing the details of an already uploaded and selected resource on the right side of the page. 

Currently it doesn't actually add the new resource. This functionality and tests will be added in the next PR, as I also want to try some UI changes for this page in general. 