### PR TITLE
Edit fields from a right panel on the `RecordSets` page.

### DIFF
--- a/editor/app.py
+++ b/editor/app.py
@@ -10,7 +10,7 @@ init_state()
 
 def _back_to_menu():
     """Sends the user back to the menu."""
-    st.session_state[CurrentStep] = CurrentStep.splash
+    init_state(force=True)
 
 
 st.set_page_config(page_title="Croissant Editor", page_icon="🥐", layout="wide")

--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -20,11 +20,21 @@ class CurrentStep:
 
 
 class SelectedResource:
+    """The selected FileSet or FileObject on the `Resources` page."""
+
     pass
 
 
 class AddManually:
     pass
+
+
+@dataclasses.dataclass
+class SelectedRecordSet:
+    """The selected RecordSet on the `RecordSets` page."""
+
+    record_set_key: int
+    record_set: RecordSet
 
 
 @dataclasses.dataclass

--- a/editor/cypress/e2e/uploadCsv.cy.js
+++ b/editor/cypress/e2e/uploadCsv.cy.js
@@ -8,7 +8,7 @@ describe('Editor loads a local CSV as a resource', () => {
   it('should display the form: Overview, Metadata, Resources, & Record Sets', () => {
     // Streamlit starts on :8501.
     cy.visit('http://localhost:8501')
-    cy.get('button').contains('Create').click()
+    cy.get('button', {timeout: 10000}).contains('Create', {timeout: 10000}).click()
 
     cy.get('[data-testid="stMarkdownContainer"]')
       .contains('Metadata')
@@ -50,5 +50,10 @@ describe('Editor loads a local CSV as a resource', () => {
     cy.get('[data-testid="stDataFrameResizable"]').contains("https://schema.org/Text")
     cy.get('[data-testid="stDataFrameResizable"]').contains("column2")
     cy.get('[data-testid="stDataFrameResizable"]').contains("https://schema.org/Integer")
+
+    // I can edit the details of the fields.
+    cy.contains('Edit fields details').click()
+    cy.get('input[aria-label="Description"]').last().type('This is a nice custom description!{enter}')
+    cy.get('[data-testid="glide-cell-2-1"]').contains("This is a nice custom description!")
   })
 })

--- a/editor/requirements.txt
+++ b/editor/requirements.txt
@@ -3,5 +3,6 @@ mlcroissant
 numpy
 pandas
 pytest
+rdflib
 requests
 streamlit

--- a/editor/utils.py
+++ b/editor/utils.py
@@ -3,6 +3,7 @@ import streamlit as st
 
 from core.state import CurrentStep
 from core.state import Metadata
+from core.state import SelectedRecordSet
 from core.state import SelectedResource
 import mlcroissant as mlc
 
@@ -20,27 +21,31 @@ def set_form_step(action, step=None):
         st.session_state[CurrentStep] = step
 
 
-def init_state():
+def init_state(force=False):
+    """Initializes the session state. `force=True` to force re-initializing it."""
 
-    if Metadata not in st.session_state:
+    if Metadata not in st.session_state or force:
         st.session_state[Metadata] = Metadata()
 
-    if mlc.Dataset not in st.session_state:
+    if mlc.Dataset not in st.session_state or force:
         st.session_state[mlc.Dataset] = None
 
-    if CurrentStep not in st.session_state:
+    if CurrentStep not in st.session_state or force:
         st.session_state[CurrentStep] = CurrentStep.splash
 
-    if SelectedResource not in st.session_state:
+    if SelectedResource not in st.session_state or force:
         st.session_state[SelectedResource] = None
+
+    if SelectedResource not in st.session_state or force:
+        st.session_state[SelectedRecordSet] = None
 
     # Uncomment those lines if you work locally in order to avoid clicks at each reload.
     # And comment all previous lines in `init_state`.
-    # if mlc.Dataset not in st.session_state:
+    # if mlc.Dataset not in st.session_state or force:
     #     st.session_state[mlc.Dataset] = mlc.Dataset("../datasets/titanic/metadata.json")
-    # if Metadata not in st.session_state:
+    # if Metadata not in st.session_state or force:
     #     st.session_state[Metadata] = Metadata.from_canonical(
     #         st.session_state[mlc.Dataset].metadata
     #     )
-    # if CurrentStep not in st.session_state:
+    # if CurrentStep not in st.session_state or force:
     #     st.session_state[CurrentStep] = CurrentStep.editor

--- a/editor/views/record_sets.py
+++ b/editor/views/record_sets.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+from rdflib import term
 import streamlit as st
 
 from core.state import Field
@@ -202,9 +203,9 @@ def _handle_fields_change(record_set_key: int, record_set: RecordSet):
         st.session_state[Metadata].update_field(record_set_key, field_key, field)
     for added_row in result["added_rows"]:
         field = Field(
-            name=added_row[FieldDataFrame.NAME],
-            description=added_row[FieldDataFrame.DESCRIPTION],
-            data_types=[added_row[FieldDataFrame.DATA_TYPE]],
+            name=added_row.get(FieldDataFrame.NAME),
+            description=added_row.get(FieldDataFrame.DESCRIPTION),
+            data_types=[added_row.get(FieldDataFrame.DATA_TYPE)],
             source=mlc.Source(
                 uid="foo",
                 node_type="distribution",
@@ -510,9 +511,15 @@ def _render_right_panel():
                 args=(Change.DESCRIPTION, record_set_key, field_key, field, key),
             )
             if field.data_types:
-                data_type_index = DATA_TYPES.index(field.data_types[0])
+                data_type = field.data_types[0]
+                if isinstance(data_type, str):
+                    data_type = term.URIRef(data_type)
+                if data_type in DATA_TYPES:
+                    data_type_index = DATA_TYPES.index(data_type)
+                else:
+                    data_type_index = None
             else:
-                data_type_index = 0
+                data_type_index = None
             key = f"{record_set.name}-{field.name}-datatypes"
             col3.selectbox(
                 needed_field("Data type"),

--- a/editor/views/record_sets.py
+++ b/editor/views/record_sets.py
@@ -1,6 +1,3 @@
-import enum
-from typing import Any
-
 import numpy as np
 import pandas as pd
 from rdflib import term
@@ -11,8 +8,11 @@ from core.state import Metadata
 from core.state import RecordSet
 from core.state import SelectedRecordSet
 import mlcroissant as mlc
-from utils import DF_HEIGHT
 from utils import needed_field
+from views.source import ChangeEvent
+from views.source import handle_field_change
+from views.source import render_references
+from views.source import render_source
 
 DATA_TYPES = [
     mlc.DataType.TEXT,
@@ -20,51 +20,6 @@ DATA_TYPES = [
     mlc.DataType.INTEGER,
     mlc.DataType.BOOL,
     mlc.DataType.URL,
-]
-
-
-class SourceType:
-    DISTRIBUTION = "distribution"
-    FIELD = "field"
-
-
-class ExtractType:
-    COLUMN = "Column"
-    JSON_PATH = "JSON path"
-    FILE_CONTENT = "File content"
-    FILE_NAME = "File name"
-    FILE_PATH = "File path"
-    FILE_FULLPATH = "Full path"
-    FILE_LINES = "Lines in file"
-    FILE_LINE_NUMBERS = "Line numbers in file"
-
-
-EXTRACT_TYPES = [
-    ExtractType.COLUMN,
-    ExtractType.JSON_PATH,
-    ExtractType.FILE_CONTENT,
-    ExtractType.FILE_NAME,
-    ExtractType.FILE_PATH,
-    ExtractType.FILE_FULLPATH,
-    ExtractType.FILE_LINES,
-    ExtractType.FILE_LINE_NUMBERS,
-]
-
-
-class TransformType:
-    FORMAT = "Apply format"
-    JSON_PATH = "Apply JSON path"
-    REGEX = "Apply regular expression"
-    REPLACE = "Replace"
-    SEPARATOR = "Separator"
-
-
-TRANSFORM_TYPES = [
-    TransformType.FORMAT,
-    TransformType.JSON_PATH,
-    TransformType.REGEX,
-    TransformType.REPLACE,
-    TransformType.SEPARATOR,
 ]
 
 
@@ -94,64 +49,6 @@ def _get_possible_sources(metadata: Metadata) -> list[str]:
         for field in record_set.fields:
             possible_sources.append(f"{record_set.name}/{field.name}")
     return possible_sources
-
-
-def _get_extract(source: mlc.Source) -> str | None:
-    if source.extract.column:
-        return ExtractType.COLUMN
-    elif source.extract.file_property:
-        file_property = source.extract.file_property
-        if file_property == mlc.FileProperty.content:
-            return ExtractType.FILE_CONTENT
-        elif file_property == mlc.FileProperty.filename:
-            return ExtractType.FILE_NAME
-        elif file_property == mlc.FileProperty.filepath:
-            return ExtractType.FILE_PATH
-        elif file_property == mlc.FileProperty.fullpath:
-            return ExtractType.FILE_FULLPATH
-        elif file_property == mlc.FileProperty.lines:
-            return ExtractType.FILE_LINES
-        elif file_property == mlc.FileProperty.lineNumbers:
-            return ExtractType.FILE_LINE_NUMBERS
-        else:
-            return None
-    elif source.extract.json_path:
-        return ExtractType.JSON_PATH
-    return None
-
-
-def _get_extract_index(source: mlc.Source) -> int | None:
-    extract = _get_extract(source)
-    if extract in EXTRACT_TYPES:
-        return EXTRACT_TYPES.index(extract)
-    return None
-
-
-def _get_transforms(source: mlc.Source) -> list[str]:
-    transforms = source.transforms
-    return [_get_transform(transform) for transform in transforms]
-
-
-def _get_transform(transform: mlc.Transform) -> str | None:
-    if transform.format:
-        return TransformType.FORMAT
-    elif transform.json_path:
-        return TransformType.JSON_PATH
-    elif transform.regex:
-        return TransformType.REGEX
-    elif transform.replace:
-        return TransformType.REPLACE
-    elif transform.separator:
-        return TransformType.SEPARATOR
-    return None
-
-
-def _get_transforms_indices(source: mlc.Source) -> list[int]:
-    transforms = _get_transforms(source)
-    return [
-        TRANSFORM_TYPES.index(transform) if transform in TRANSFORM_TYPES else None
-        for transform in transforms
-    ]
 
 
 LeftOrRight = tuple[str, str]
@@ -368,118 +265,6 @@ def _render_left_panel():
             )
 
 
-class Change(enum.Enum):
-    NAME = "NAME"
-    DESCRIPTION = "DESCRIPTION"
-    DATA_TYPE = "DATA_TYPE"
-    SOURCE = "SOURCE"
-    SOURCE_EXTRACT = "SOURCE_EXTRACT"
-    SOURCE_EXTRACT_COLUMN = "SOURCE_EXTRACT_COLUMN"
-    SOURCE_EXTRACT_JSON_PATH = "SOURCE_EXTRACT_JSON_PATH"
-    TRANSFORM = "TRANSFORM"
-    TRANSFORM_FORMAT = "TRANSFORM_FORMAT"
-    REFERENCE = "REFERENCE"
-    REFERENCE_EXTRACT = "REFERENCE_EXTRACT"
-    REFERENCE_EXTRACT_COLUMN = "REFERENCE_EXTRACT_COLUMN"
-    REFERENCE_EXTRACT_JSON_PATH = "REFERENCE_EXTRACT_JSON_PATH"
-
-
-def _get_source(source: mlc.Source | None, value: Any) -> mlc.Source:
-    if not source:
-        source = mlc.Source(extract=mlc.Extract())
-    if value == ExtractType.COLUMN:
-        source.extract = mlc.Extract(column="")
-    elif value == ExtractType.FILE_CONTENT:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.content)
-    elif value == ExtractType.FILE_NAME:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.filename)
-    elif value == ExtractType.FILE_PATH:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.filepath)
-    elif value == ExtractType.FILE_FULLPATH:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.fullpath)
-    elif value == ExtractType.FILE_LINES:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.lines)
-    elif value == ExtractType.FILE_LINE_NUMBERS:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.lineNumbers)
-    elif value == ExtractType.JSON_PATH:
-        source.extract = mlc.Extract(json_path="")
-    return source
-
-
-def _handle_field_change(
-    change: Change,
-    record_set_key: int,
-    field_key: int,
-    field: Field,
-    key: str,
-    **kwargs,
-):
-    value = st.session_state[key]
-    if change == Change.NAME:
-        field.name = value
-    elif change == Change.DESCRIPTION:
-        field.description = value
-    elif change == Change.DATA_TYPE:
-        field.data_types = [value]
-    elif change == Change.SOURCE:
-        node_type = "field" if "/" in value else "distribution"
-        source = mlc.Source(uid=value, node_type=node_type)
-        field.source = source
-    elif change == Change.SOURCE_EXTRACT:
-        source = field.source
-        source = _get_source(source, value)
-        field.source = source
-    elif change == Change.SOURCE_EXTRACT_COLUMN:
-        if not field.source:
-            field.source = mlc.Source(extract=mlc.Extract())
-        field.source.extract = mlc.Extract(column=value)
-    elif change == Change.SOURCE_EXTRACT_JSON_PATH:
-        if not field.source:
-            field.source = mlc.Source(extract=mlc.Extract())
-        field.source.extract = mlc.Extract(json_path=value)
-    elif change == Change.TRANSFORM:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform()
-    elif change == TransformType.FORMAT:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform(format=value)
-    elif change == TransformType.JSON_PATH:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform(json_path=value)
-    elif change == TransformType.REGEX:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform(regex=value)
-    elif change == TransformType.REPLACE:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform(replace=value)
-    elif change == TransformType.SEPARATOR:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform(separator=value)
-    elif change == Change.REFERENCE:
-        node_type = "field" if "/" in value else "distribution"
-        source = mlc.Source(uid=value, node_type=node_type)
-        field.references = source
-    elif change == Change.REFERENCE_EXTRACT:
-        source = field.references
-        source = _get_source(source, value)
-        field.references = source
-    elif change == Change.REFERENCE_EXTRACT_COLUMN:
-        if not field.references:
-            field.references = mlc.Source(extract=mlc.Extract())
-        field.references.extract = mlc.Extract(column=value)
-    elif change == Change.REFERENCE_EXTRACT_JSON_PATH:
-        if not field.references:
-            field.references = mlc.Source(extract=mlc.Extract())
-        field.references.extract = mlc.Extract(json_path=value)
-    st.session_state[Metadata].update_field(record_set_key, field_key, field)
-
-
 def _render_right_panel():
     """Right panel: visualization of the clicked Field."""
     metadata: Metadata = st.session_state.get(Metadata)
@@ -498,17 +283,17 @@ def _render_right_panel():
                 placeholder="Name without special character.",
                 key=key,
                 value=field.name,
-                on_change=_handle_field_change,
-                args=(Change.NAME, record_set_key, field_key, field, key),
+                on_change=handle_field_change,
+                args=(ChangeEvent.NAME, record_set_key, field_key, field, key),
             )
             key = f"{record_set.name}-{field.name}-description"
             col2.text_input(
                 "Description",
                 placeholder="Provide a clear description of the RecordSet.",
                 key=key,
-                on_change=_handle_field_change,
+                on_change=handle_field_change,
                 value=field.description,
-                args=(Change.DESCRIPTION, record_set_key, field_key, field, key),
+                args=(ChangeEvent.DESCRIPTION, record_set_key, field_key, field, key),
             )
             if field.data_types:
                 data_type = field.data_types[0]
@@ -526,14 +311,14 @@ def _render_right_panel():
                 index=data_type_index,
                 options=DATA_TYPES,
                 key=key,
-                on_change=_handle_field_change,
-                args=(Change.DATA_TYPE, record_set_key, field_key, field, key),
+                on_change=handle_field_change,
+                args=(ChangeEvent.DATA_TYPE, record_set_key, field_key, field, key),
             )
             possible_sources = _get_possible_sources(metadata)
-            _render_source(
+            render_source(
                 record_set_key, record_set, field, field_key, possible_sources
             )
-            _render_references(
+            render_references(
                 record_set_key, record_set, field, field_key, possible_sources
             )
 
@@ -544,234 +329,4 @@ def _render_right_panel():
             key=f"{record_set.name}-close-fields",
             type="primary",
             on_click=_handle_close_fields,
-        )
-
-
-def _render_source(
-    record_set_key: int,
-    record_set: RecordSet,
-    field: Field,
-    field_key: int,
-    possible_sources: list[str],
-):
-    source = field.source
-    postfix = f"source-{record_set.name}-{field.name}"
-    col1, col2, col3 = st.columns([1, 1, 1])
-    index = (
-        possible_sources.index(source.uid) if source.uid in possible_sources else None
-    )
-    key = f"{postfix}-source"
-    col1.selectbox(
-        needed_field("Source"),
-        index=index,
-        options=[s for s in possible_sources if not s.startswith(record_set.name)],
-        key=key,
-        on_change=_handle_field_change,
-        args=(Change.SOURCE, record_set_key, field_key, field, key),
-    )
-    if source.node_type == "distribution":
-        extract = col2.selectbox(
-            needed_field("Extract"),
-            index=_get_extract_index(source),
-            key=f"{postfix}-extract",
-            options=EXTRACT_TYPES,
-            on_change=_handle_field_change,
-            args=(Change.SOURCE_EXTRACT, record_set_key, field_key, field, key),
-        )
-        if extract == ExtractType.COLUMN:
-            key = f"{postfix}-columnname"
-            col3.text_input(
-                needed_field("Column name"),
-                value=source.extract.column,
-                key=key,
-                on_change=_handle_field_change,
-                args=(
-                    Change.SOURCE_EXTRACT_COLUMN,
-                    record_set_key,
-                    field_key,
-                    field,
-                    key,
-                ),
-            )
-        if extract == ExtractType.JSON_PATH:
-            key = f"{postfix}-jsonpath"
-            col3.text_input(
-                needed_field("JSON path"),
-                value=source.extract.json_path,
-                key=key,
-                on_change=_handle_field_change,
-                args=(
-                    Change.SOURCE_EXTRACT_JSON_PATH,
-                    record_set_key,
-                    field_key,
-                    field,
-                    key,
-                ),
-            )
-
-    # Transforms
-    indices = _get_transforms_indices(field.source)
-    if source.transforms:
-        for number, (index, transform) in enumerate(zip(indices, source.transforms)):
-            _, col2, col3, col4 = st.columns([4.5, 4, 4, 1])
-            key = f"{postfix}-{number}-transform"
-            selected = col2.selectbox(
-                "Transform",
-                index=index,
-                key=key,
-                options=TRANSFORM_TYPES,
-                on_change=_handle_field_change,
-                args=(Change.TRANSFORM, record_set_key, field_key, field, key),
-                kwargs={"number": number},
-            )
-            if selected == TransformType.FORMAT:
-                key = f"{postfix}-{number}-transform-format"
-                col3.text_input(
-                    needed_field("Format"),
-                    value=transform.format,
-                    key=key,
-                    on_change=_handle_field_change,
-                    args=(selected, record_set_key, field_key, field, key),
-                    kwargs={"number": number, "type": "format"},
-                )
-            elif selected == TransformType.JSON_PATH:
-                key = f"{postfix}-{number}-jsonpath"
-                col3.text_input(
-                    needed_field("JSON path"),
-                    value=transform.json_path,
-                    key=key,
-                    on_change=_handle_field_change,
-                    args=(selected, record_set_key, field_key, field, key),
-                    kwargs={"number": number, "type": "format"},
-                )
-            elif selected == TransformType.REGEX:
-                key = f"{postfix}-{number}-regex"
-                col3.text_input(
-                    needed_field("Regular expression"),
-                    value=transform.regex,
-                    key=key,
-                    on_change=_handle_field_change,
-                    args=(selected, record_set_key, field_key, field, key),
-                    kwargs={"number": number, "type": "format"},
-                )
-            elif selected == TransformType.REPLACE:
-                key = f"{postfix}-{number}-replace"
-                col3.text_input(
-                    needed_field("Replace pattern"),
-                    value=transform.replace,
-                    key=key,
-                    on_change=_handle_field_change,
-                    args=(selected, record_set_key, field_key, field, key),
-                    kwargs={"number": number, "type": "format"},
-                )
-            elif selected == TransformType.SEPARATOR:
-                key = f"{postfix}-{number}-separator"
-                col3.text_input(
-                    needed_field("Separator"),
-                    value=transform.separator,
-                    key=key,
-                    on_change=_handle_field_change,
-                    args=(selected, record_set_key, field_key, field, key),
-                    kwargs={"number": number, "type": "format"},
-                )
-
-            def _handle_remove_transform(record_set_key, field_key, field, number):
-                del field.source.transforms[number]
-                st.session_state[Metadata].update_field(
-                    record_set_key, field_key, field
-                )
-
-            col4.button(
-                "✖️",
-                key=f"{postfix}-{number}-remove-transform",
-                on_click=_handle_remove_transform,
-                args=(record_set_key, field_key, field, number),
-            )
-
-    def _handle_add_transform(record_set_key, field_key, field):
-        if not field.source:
-            field.source = mlc.Source(transforms=[])
-        field.source.transforms.append(mlc.Transform())
-        st.session_state[Metadata].update_field(record_set_key, field_key, field)
-
-    col1, _, _ = st.columns([1, 1, 1])
-    col1.button(
-        "Add transform on data",
-        key=f"{postfix}-close-fields",
-        on_click=_handle_add_transform,
-        args=(record_set_key, field_key, field),
-    )
-
-
-def _render_references(
-    record_set_key: int,
-    record_set: RecordSet,
-    field: Field,
-    field_key: int,
-    possible_sources: list[str],
-):
-    key = f"references-{record_set.name}-{field.name}"
-    button_key = f"{key}-add-reference"
-    has_clicked_button = st.session_state.get(button_key)
-    references = field.references
-    if references or has_clicked_button:
-        col1, col2, col3 = st.columns([1, 1, 1])
-        index = (
-            possible_sources.index(references.uid)
-            if references.uid in possible_sources
-            else None
-        )
-        key = f"{key}-reference"
-        col1.selectbox(
-            needed_field("Reference"),
-            index=index,
-            options=[s for s in possible_sources if not s.startswith(record_set.name)],
-            key=key,
-            on_change=_handle_field_change,
-            args=(Change.REFERENCE, record_set_key, field_key, field, key),
-        )
-        if references.node_type == "distribution":
-            key = f"{key}-extract-references"
-            extract = col2.selectbox(
-                needed_field("Extract the reference"),
-                index=_get_extract_index(references),
-                key=key,
-                options=EXTRACT_TYPES,
-                on_change=_handle_field_change,
-                args=(Change.REFERENCE_EXTRACT, record_set_key, field_key, field, key),
-            )
-            if extract == ExtractType.COLUMN:
-                key = f"{key}-columnname"
-                col3.text_input(
-                    needed_field("Column name"),
-                    value=references.extract.column,
-                    key=key,
-                    on_change=_handle_field_change,
-                    args=(
-                        Change.REFERENCE_EXTRACT_COLUMN,
-                        record_set_key,
-                        field_key,
-                        field,
-                        key,
-                    ),
-                )
-            if extract == ExtractType.JSON_PATH:
-                key = f"{key}-jsonpath"
-                col3.text_input(
-                    needed_field("JSON path"),
-                    value=references.extract.json_path,
-                    key=key,
-                    on_change=_handle_field_change,
-                    args=(
-                        Change.REFERENCE_EXTRACT_JSON_PATH,
-                        record_set_key,
-                        field_key,
-                        field,
-                        key,
-                    ),
-                )
-    elif not has_clicked_button:
-        st.button(
-            "Add a join with another column/field",
-            key=button_key,
         )

--- a/editor/views/record_sets_test.py
+++ b/editor/views/record_sets_test.py
@@ -19,10 +19,10 @@ def test_find_joins():
             references=mlc.Source(uid="some_other_record_set/some_other_field"),
         ),
     ]
-    assert _find_joins(fields) == [
+    assert _find_joins(fields) == set([
         (("some_csv", "some_column"), ("some_record_set", "some_field")),
         (
             ("some_record_set", "some_field"),
             ("some_other_record_set", "some_other_field"),
         ),
-    ]
+    ])

--- a/editor/views/source.py
+++ b/editor/views/source.py
@@ -121,6 +121,12 @@ def _get_transforms_indices(source: mlc.Source) -> list[int]:
     ]
 
 
+def _handle_remove_reference(record_set_key, field_key, field):
+    """Removes the reference from a field."""
+    field.references = None
+    st.session_state[Metadata].update_field(record_set_key, field_key, field)
+
+
 class ChangeEvent(enum.Enum):
     """Event that triggers a field change."""
 
@@ -405,7 +411,7 @@ def render_references(
     has_clicked_button = st.session_state.get(button_key)
     references = field.references
     if references or has_clicked_button:
-        col1, col2, col3 = st.columns([1, 1, 1])
+        col1, col2, col3, col4 = st.columns([4.5, 4, 4, 1])
         index = (
             possible_sources.index(references.uid)
             if references.uid in possible_sources
@@ -413,7 +419,7 @@ def render_references(
         )
         key = f"{key}-reference"
         col1.selectbox(
-            needed_field("Reference"),
+            "Reference",
             index=index,
             options=[s for s in possible_sources if not s.startswith(record_set.name)],
             key=key,
@@ -466,6 +472,12 @@ def render_references(
                         key,
                     ),
                 )
+        col4.button(
+            "✖️",
+            key=f"{key}-remove-reference",
+            on_click=_handle_remove_reference,
+            args=(record_set_key, field_key, field),
+        )
     elif not has_clicked_button:
         st.button(
             "Add a join with another column/field",

--- a/editor/views/source.py
+++ b/editor/views/source.py
@@ -1,0 +1,473 @@
+import enum
+from typing import Any
+
+import streamlit as st
+
+from core.state import Field
+from core.state import Metadata
+from core.state import RecordSet
+import mlcroissant as mlc
+from utils import DF_HEIGHT
+from utils import needed_field
+
+
+class SourceType:
+    """The type of the source (distribution or field)."""
+
+    DISTRIBUTION = "distribution"
+    FIELD = "field"
+
+
+class ExtractType:
+    """The type of extraction to perform."""
+
+    COLUMN = "Column"
+    JSON_PATH = "JSON path"
+    FILE_CONTENT = "File content"
+    FILE_NAME = "File name"
+    FILE_PATH = "File path"
+    FILE_FULLPATH = "Full path"
+    FILE_LINES = "Lines in file"
+    FILE_LINE_NUMBERS = "Line numbers in file"
+
+
+EXTRACT_TYPES = [
+    ExtractType.COLUMN,
+    ExtractType.JSON_PATH,
+    ExtractType.FILE_CONTENT,
+    ExtractType.FILE_NAME,
+    ExtractType.FILE_PATH,
+    ExtractType.FILE_FULLPATH,
+    ExtractType.FILE_LINES,
+    ExtractType.FILE_LINE_NUMBERS,
+]
+
+
+class TransformType:
+    """The type of transformation to perform."""
+
+    FORMAT = "Apply format"
+    JSON_PATH = "Apply JSON path"
+    REGEX = "Apply regular expression"
+    REPLACE = "Replace"
+    SEPARATOR = "Separator"
+
+
+# TODO(marcenacp): Possible to remove?
+TRANSFORM_TYPES = [
+    TransformType.FORMAT,
+    TransformType.JSON_PATH,
+    TransformType.REGEX,
+    TransformType.REPLACE,
+    TransformType.SEPARATOR,
+]
+
+
+def _get_extract(source: mlc.Source) -> str | None:
+    if source.extract.column:
+        return ExtractType.COLUMN
+    elif source.extract.file_property:
+        file_property = source.extract.file_property
+        if file_property == mlc.FileProperty.content:
+            return ExtractType.FILE_CONTENT
+        elif file_property == mlc.FileProperty.filename:
+            return ExtractType.FILE_NAME
+        elif file_property == mlc.FileProperty.filepath:
+            return ExtractType.FILE_PATH
+        elif file_property == mlc.FileProperty.fullpath:
+            return ExtractType.FILE_FULLPATH
+        elif file_property == mlc.FileProperty.lines:
+            return ExtractType.FILE_LINES
+        elif file_property == mlc.FileProperty.lineNumbers:
+            return ExtractType.FILE_LINE_NUMBERS
+        else:
+            return None
+    elif source.extract.json_path:
+        return ExtractType.JSON_PATH
+    return None
+
+
+def _get_extract_index(source: mlc.Source) -> int | None:
+    extract = _get_extract(source)
+    if extract in EXTRACT_TYPES:
+        return EXTRACT_TYPES.index(extract)
+    return None
+
+
+def _get_transforms(source: mlc.Source) -> list[str]:
+    transforms = source.transforms
+    return [_get_transform(transform) for transform in transforms]
+
+
+def _get_transform(transform: mlc.Transform) -> str | None:
+    if transform.format:
+        return TransformType.FORMAT
+    elif transform.json_path:
+        return TransformType.JSON_PATH
+    elif transform.regex:
+        return TransformType.REGEX
+    elif transform.replace:
+        return TransformType.REPLACE
+    elif transform.separator:
+        return TransformType.SEPARATOR
+    return None
+
+
+def _get_transforms_indices(source: mlc.Source) -> list[int]:
+    transforms = _get_transforms(source)
+    return [
+        TRANSFORM_TYPES.index(transform) if transform in TRANSFORM_TYPES else None
+        for transform in transforms
+    ]
+
+
+class ChangeEvent(enum.Enum):
+    """Event that triggers a field change."""
+
+    NAME = "NAME"
+    DESCRIPTION = "DESCRIPTION"
+    DATA_TYPE = "DATA_TYPE"
+    SOURCE = "SOURCE"
+    SOURCE_EXTRACT = "SOURCE_EXTRACT"
+    SOURCE_EXTRACT_COLUMN = "SOURCE_EXTRACT_COLUMN"
+    SOURCE_EXTRACT_JSON_PATH = "SOURCE_EXTRACT_JSON_PATH"
+    TRANSFORM = "TRANSFORM"
+    TRANSFORM_FORMAT = "TRANSFORM_FORMAT"
+    REFERENCE = "REFERENCE"
+    REFERENCE_EXTRACT = "REFERENCE_EXTRACT"
+    REFERENCE_EXTRACT_COLUMN = "REFERENCE_EXTRACT_COLUMN"
+    REFERENCE_EXTRACT_JSON_PATH = "REFERENCE_EXTRACT_JSON_PATH"
+
+
+def _get_source(source: mlc.Source | None, value: Any) -> mlc.Source:
+    if not source:
+        source = mlc.Source(extract=mlc.Extract())
+    if value == ExtractType.COLUMN:
+        source.extract = mlc.Extract(column="")
+    elif value == ExtractType.FILE_CONTENT:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.content)
+    elif value == ExtractType.FILE_NAME:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.filename)
+    elif value == ExtractType.FILE_PATH:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.filepath)
+    elif value == ExtractType.FILE_FULLPATH:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.fullpath)
+    elif value == ExtractType.FILE_LINES:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.lines)
+    elif value == ExtractType.FILE_LINE_NUMBERS:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.lineNumbers)
+    elif value == ExtractType.JSON_PATH:
+        source.extract = mlc.Extract(json_path="")
+    return source
+
+
+def handle_field_change(
+    change: ChangeEvent,
+    record_set_key: int,
+    field_key: int,
+    field: Field,
+    key: str,
+    **kwargs,
+):
+    value = st.session_state[key]
+    if change == ChangeEvent.NAME:
+        field.name = value
+    elif change == ChangeEvent.DESCRIPTION:
+        field.description = value
+    elif change == ChangeEvent.DATA_TYPE:
+        field.data_types = [value]
+    elif change == ChangeEvent.SOURCE:
+        node_type = "field" if "/" in value else "distribution"
+        source = mlc.Source(uid=value, node_type=node_type)
+        field.source = source
+    elif change == ChangeEvent.SOURCE_EXTRACT:
+        source = field.source
+        source = _get_source(source, value)
+        field.source = source
+    elif change == ChangeEvent.SOURCE_EXTRACT_COLUMN:
+        if not field.source:
+            field.source = mlc.Source(extract=mlc.Extract())
+        field.source.extract = mlc.Extract(column=value)
+    elif change == ChangeEvent.SOURCE_EXTRACT_JSON_PATH:
+        if not field.source:
+            field.source = mlc.Source(extract=mlc.Extract())
+        field.source.extract = mlc.Extract(json_path=value)
+    elif change == ChangeEvent.TRANSFORM:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform()
+    elif change == TransformType.FORMAT:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform(format=value)
+    elif change == TransformType.JSON_PATH:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform(json_path=value)
+    elif change == TransformType.REGEX:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform(regex=value)
+    elif change == TransformType.REPLACE:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform(replace=value)
+    elif change == TransformType.SEPARATOR:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform(separator=value)
+    elif change == ChangeEvent.REFERENCE:
+        node_type = "field" if "/" in value else "distribution"
+        source = mlc.Source(uid=value, node_type=node_type)
+        field.references = source
+    elif change == ChangeEvent.REFERENCE_EXTRACT:
+        source = field.references
+        source = _get_source(source, value)
+        field.references = source
+    elif change == ChangeEvent.REFERENCE_EXTRACT_COLUMN:
+        if not field.references:
+            field.references = mlc.Source(extract=mlc.Extract())
+        field.references.extract = mlc.Extract(column=value)
+    elif change == ChangeEvent.REFERENCE_EXTRACT_JSON_PATH:
+        if not field.references:
+            field.references = mlc.Source(extract=mlc.Extract())
+        field.references.extract = mlc.Extract(json_path=value)
+    st.session_state[Metadata].update_field(record_set_key, field_key, field)
+
+
+def render_source(
+    record_set_key: int,
+    record_set: RecordSet,
+    field: Field,
+    field_key: int,
+    possible_sources: list[str],
+):
+    """Renders the form for the source."""
+    source = field.source
+    postfix = f"source-{record_set.name}-{field.name}"
+    col1, col2, col3 = st.columns([1, 1, 1])
+    index = (
+        possible_sources.index(source.uid) if source.uid in possible_sources else None
+    )
+    key = f"{postfix}-source"
+    col1.selectbox(
+        needed_field("Source"),
+        index=index,
+        options=[s for s in possible_sources if not s.startswith(record_set.name)],
+        key=key,
+        on_change=handle_field_change,
+        args=(ChangeEvent.SOURCE, record_set_key, field_key, field, key),
+    )
+    if source.node_type == "distribution":
+        extract = col2.selectbox(
+            needed_field("Extract"),
+            index=_get_extract_index(source),
+            key=f"{postfix}-extract",
+            options=EXTRACT_TYPES,
+            on_change=handle_field_change,
+            args=(ChangeEvent.SOURCE_EXTRACT, record_set_key, field_key, field, key),
+        )
+        if extract == ExtractType.COLUMN:
+            key = f"{postfix}-columnname"
+            col3.text_input(
+                needed_field("Column name"),
+                value=source.extract.column,
+                key=key,
+                on_change=handle_field_change,
+                args=(
+                    ChangeEvent.SOURCE_EXTRACT_COLUMN,
+                    record_set_key,
+                    field_key,
+                    field,
+                    key,
+                ),
+            )
+        if extract == ExtractType.JSON_PATH:
+            key = f"{postfix}-jsonpath"
+            col3.text_input(
+                needed_field("JSON path"),
+                value=source.extract.json_path,
+                key=key,
+                on_change=handle_field_change,
+                args=(
+                    ChangeEvent.SOURCE_EXTRACT_JSON_PATH,
+                    record_set_key,
+                    field_key,
+                    field,
+                    key,
+                ),
+            )
+
+    # Transforms
+    indices = _get_transforms_indices(field.source)
+    if source.transforms:
+        for number, (index, transform) in enumerate(zip(indices, source.transforms)):
+            _, col2, col3, col4 = st.columns([4.5, 4, 4, 1])
+            key = f"{postfix}-{number}-transform"
+            selected = col2.selectbox(
+                "Transform",
+                index=index,
+                key=key,
+                options=TRANSFORM_TYPES,
+                on_change=handle_field_change,
+                args=(ChangeEvent.TRANSFORM, record_set_key, field_key, field, key),
+                kwargs={"number": number},
+            )
+            if selected == TransformType.FORMAT:
+                key = f"{postfix}-{number}-transform-format"
+                col3.text_input(
+                    needed_field("Format"),
+                    value=transform.format,
+                    key=key,
+                    on_change=handle_field_change,
+                    args=(selected, record_set_key, field_key, field, key),
+                    kwargs={"number": number, "type": "format"},
+                )
+            elif selected == TransformType.JSON_PATH:
+                key = f"{postfix}-{number}-jsonpath"
+                col3.text_input(
+                    needed_field("JSON path"),
+                    value=transform.json_path,
+                    key=key,
+                    on_change=handle_field_change,
+                    args=(selected, record_set_key, field_key, field, key),
+                    kwargs={"number": number, "type": "format"},
+                )
+            elif selected == TransformType.REGEX:
+                key = f"{postfix}-{number}-regex"
+                col3.text_input(
+                    needed_field("Regular expression"),
+                    value=transform.regex,
+                    key=key,
+                    on_change=handle_field_change,
+                    args=(selected, record_set_key, field_key, field, key),
+                    kwargs={"number": number, "type": "format"},
+                )
+            elif selected == TransformType.REPLACE:
+                key = f"{postfix}-{number}-replace"
+                col3.text_input(
+                    needed_field("Replace pattern"),
+                    value=transform.replace,
+                    key=key,
+                    on_change=handle_field_change,
+                    args=(selected, record_set_key, field_key, field, key),
+                    kwargs={"number": number, "type": "format"},
+                )
+            elif selected == TransformType.SEPARATOR:
+                key = f"{postfix}-{number}-separator"
+                col3.text_input(
+                    needed_field("Separator"),
+                    value=transform.separator,
+                    key=key,
+                    on_change=handle_field_change,
+                    args=(selected, record_set_key, field_key, field, key),
+                    kwargs={"number": number, "type": "format"},
+                )
+
+            def _handle_remove_transform(record_set_key, field_key, field, number):
+                del field.source.transforms[number]
+                st.session_state[Metadata].update_field(
+                    record_set_key, field_key, field
+                )
+
+            col4.button(
+                "✖️",
+                key=f"{postfix}-{number}-remove-transform",
+                on_click=_handle_remove_transform,
+                args=(record_set_key, field_key, field, number),
+            )
+
+    def _handle_add_transform(record_set_key, field_key, field):
+        if not field.source:
+            field.source = mlc.Source(transforms=[])
+        field.source.transforms.append(mlc.Transform())
+        st.session_state[Metadata].update_field(record_set_key, field_key, field)
+
+    col1, _, _ = st.columns([1, 1, 1])
+    col1.button(
+        "Add transform on data",
+        key=f"{postfix}-close-fields",
+        on_click=_handle_add_transform,
+        args=(record_set_key, field_key, field),
+    )
+
+
+def render_references(
+    record_set_key: int,
+    record_set: RecordSet,
+    field: Field,
+    field_key: int,
+    possible_sources: list[str],
+):
+    """Renders the form for references."""
+    key = f"references-{record_set.name}-{field.name}"
+    button_key = f"{key}-add-reference"
+    has_clicked_button = st.session_state.get(button_key)
+    references = field.references
+    if references or has_clicked_button:
+        col1, col2, col3 = st.columns([1, 1, 1])
+        index = (
+            possible_sources.index(references.uid)
+            if references.uid in possible_sources
+            else None
+        )
+        key = f"{key}-reference"
+        col1.selectbox(
+            needed_field("Reference"),
+            index=index,
+            options=[s for s in possible_sources if not s.startswith(record_set.name)],
+            key=key,
+            on_change=handle_field_change,
+            args=(ChangeEvent.REFERENCE, record_set_key, field_key, field, key),
+        )
+        if references.node_type == "distribution":
+            key = f"{key}-extract-references"
+            extract = col2.selectbox(
+                needed_field("Extract the reference"),
+                index=_get_extract_index(references),
+                key=key,
+                options=EXTRACT_TYPES,
+                on_change=handle_field_change,
+                args=(
+                    ChangeEvent.REFERENCE_EXTRACT,
+                    record_set_key,
+                    field_key,
+                    field,
+                    key,
+                ),
+            )
+            if extract == ExtractType.COLUMN:
+                key = f"{key}-columnname"
+                col3.text_input(
+                    needed_field("Column name"),
+                    value=references.extract.column,
+                    key=key,
+                    on_change=handle_field_change,
+                    args=(
+                        ChangeEvent.REFERENCE_EXTRACT_COLUMN,
+                        record_set_key,
+                        field_key,
+                        field,
+                        key,
+                    ),
+                )
+            if extract == ExtractType.JSON_PATH:
+                key = f"{key}-jsonpath"
+                col3.text_input(
+                    needed_field("JSON path"),
+                    value=references.extract.json_path,
+                    key=key,
+                    on_change=handle_field_change,
+                    args=(
+                        ChangeEvent.REFERENCE_EXTRACT_JSON_PATH,
+                        record_set_key,
+                        field_key,
+                        field,
+                        key,
+                    ),
+                )
+    elif not has_clicked_button:
+        st.button(
+            "Add a join with another column/field",
+            key=button_key,
+        )


### PR DESCRIPTION
- Edit fields from a right panel on the RecordSets page.
- Display references in ml:Fields.
- Add transforms.
- Add references.
- Convert data_types to RDFLib-compatible URIRefs.
- Split code in files for readability.
- Add an e2e test in Cypress.
- Re-initialize state when going back to the menu.