### PR TITLE
Remove unused AddManually field

### DIFF
--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -25,10 +25,6 @@ class SelectedResource:
     pass
 
 
-class AddManually:
-    pass
-
-
 @dataclasses.dataclass
 class SelectedRecordSet:
     """The selected RecordSet on the `RecordSets` page."""

--- a/editor/views/files.py
+++ b/editor/views/files.py
@@ -6,7 +6,6 @@ from core.files import file_from_upload
 from core.files import file_from_url
 from core.files import FILE_TYPES
 from core.record_sets import infer_record_sets
-from core.state import AddManually
 from core.state import FileObject
 from core.state import FileSet
 from core.state import Metadata


### PR DESCRIPTION
Removes a field that was accidentally leftover when used for the Add manually button which was replaced in the next PR.