### PR TITLE
Do not overwrite objects at each run (but rather manage fine-grained events).

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,6 +46,8 @@
         "--project",
         "core",
         "--project",
+        "events",
+        "--project",
         "views",
         "--project",
         "state",

--- a/editor/Makefile
+++ b/editor/Makefile
@@ -12,6 +12,7 @@ isort:
 		--project mlcroissant \
 		--project components \
 		--project core \
+		--project events \
 		--project views \
 		--project state \
 		--project utils \

--- a/editor/core/record_sets.py
+++ b/editor/core/record_sets.py
@@ -32,7 +32,6 @@ def infer_record_sets(file: FileObject | FileSet, names: set[str]) -> list[Recor
     return [
         RecordSet(
             fields=fields,
-            # TODO(marcenacp): The `name` should be unique.
             name=find_unique_name(names, file.name + "_record_set"),
             description="",
         )

--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -218,7 +218,6 @@ class Metadata:
     def add_field(self, record_set_key: int, field: Field) -> None:
         record_set = self._find_record_set(record_set_key)
         record_set.fields.append(field)
-        self.update_record_set(record_set_key, record_set)
 
     def update_field(
         self, record_set_key: int, field_key: int, field: RecordSet
@@ -231,14 +230,12 @@ class Metadata:
         if old_name != new_name:
             self.rename_field(old_name=old_name, new_name=new_name)
         record_set.fields[field_key] = field
-        self.update_record_set(record_set_key, record_set)
 
     def remove_field(self, record_set_key: int, field_key: int) -> None:
         record_set = self._find_record_set(record_set_key)
         if field_key >= len(record_set.fields):
             raise ValueError(f"Wrong index when removing field: {field_key}")
         del record_set.fields[field_key]
-        self.update_record_set(record_set_key, record_set)
 
     def to_canonical(self) -> mlc.Metadata:
         distribution = []

--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -6,6 +6,7 @@ In the future, this could be the serialization format between front and back.
 from __future__ import annotations
 
 import dataclasses
+import enum
 from typing import Any
 
 import pandas as pd
@@ -170,42 +171,14 @@ class Metadata:
                     new_uid = references.uid.replace(old_name, new_name, 1)
                     self.record_sets[i].fields[j].references.uid = new_uid
 
-    def update_metadata(
-        self,
-        description: str,
-        citation: str,
-        license: license,
-        url: str = "",
-        name: str = "",
-    ) -> None:
-        self.name = name
-        self.description = description
-        self.citation = citation
-        self.license = license
-        self.url = url
-
     def add_distribution(self, distribution: FileSet | FileObject) -> None:
         self.distribution.append(distribution)
-
-    def update_distribution(self, key: int, distribution: FileSet | FileObject) -> None:
-        old_name = self.distribution[key].name
-        new_name = distribution.name
-        if old_name != new_name:
-            self.rename_distribution(old_name=old_name, new_name=new_name)
-        self.distribution[key] = distribution
 
     def remove_distribution(self, key: int) -> None:
         del self.distribution[key]
 
     def add_record_set(self, record_set: RecordSet) -> None:
         self.record_sets.append(record_set)
-
-    def update_record_set(self, key: int, record_set: RecordSet) -> None:
-        old_name = self.record_sets[key].name
-        new_name = record_set.name
-        if old_name != new_name:
-            self.rename_record_set(old_name=old_name, new_name=new_name)
-        self.record_sets[key] = record_set
 
     def remove_record_set(self, key: int) -> None:
         del self.record_sets[key]
@@ -218,18 +191,6 @@ class Metadata:
     def add_field(self, record_set_key: int, field: Field) -> None:
         record_set = self._find_record_set(record_set_key)
         record_set.fields.append(field)
-
-    def update_field(
-        self, record_set_key: int, field_key: int, field: RecordSet
-    ) -> None:
-        record_set = self._find_record_set(record_set_key)
-        if field_key >= len(record_set.fields):
-            raise ValueError(f"Wrong index when updating field: {field_key}")
-        old_name = record_set.fields[field_key].name
-        new_name = field.name
-        if old_name != new_name:
-            self.rename_field(old_name=old_name, new_name=new_name)
-        record_set.fields[field_key] = field
 
     def remove_field(self, record_set_key: int, field_key: int) -> None:
         record_set = self._find_record_set(record_set_key)

--- a/editor/events/fields.py
+++ b/editor/events/fields.py
@@ -1,0 +1,147 @@
+import enum
+from typing import Any
+
+import streamlit as st
+
+from core.state import Field
+from core.state import Metadata
+import mlcroissant as mlc
+
+
+class ExtractType:
+    """The type of extraction to perform."""
+
+    COLUMN = "Column"
+    JSON_PATH = "JSON path"
+    FILE_CONTENT = "File content"
+    FILE_NAME = "File name"
+    FILE_PATH = "File path"
+    FILE_FULLPATH = "Full path"
+    FILE_LINES = "Lines in file"
+    FILE_LINE_NUMBERS = "Line numbers in file"
+
+
+class TransformType:
+    """The type of transformation to perform."""
+
+    FORMAT = "Apply format"
+    JSON_PATH = "Apply JSON path"
+    REGEX = "Apply regular expression"
+    REPLACE = "Replace"
+    SEPARATOR = "Separator"
+
+
+def _get_source(source: mlc.Source | None, value: Any) -> mlc.Source:
+    if not source:
+        source = mlc.Source(extract=mlc.Extract())
+    if value == ExtractType.COLUMN:
+        source.extract = mlc.Extract(column="")
+    elif value == ExtractType.FILE_CONTENT:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.content)
+    elif value == ExtractType.FILE_NAME:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.filename)
+    elif value == ExtractType.FILE_PATH:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.filepath)
+    elif value == ExtractType.FILE_FULLPATH:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.fullpath)
+    elif value == ExtractType.FILE_LINES:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.lines)
+    elif value == ExtractType.FILE_LINE_NUMBERS:
+        source.extract = mlc.Extract(file_property=mlc.FileProperty.lineNumbers)
+    elif value == ExtractType.JSON_PATH:
+        source.extract = mlc.Extract(json_path="")
+    return source
+
+
+class FieldEvent(enum.Enum):
+    """Event that triggers a field change."""
+
+    NAME = "NAME"
+    DESCRIPTION = "DESCRIPTION"
+    DATA_TYPE = "DATA_TYPE"
+    SOURCE = "SOURCE"
+    SOURCE_EXTRACT = "SOURCE_EXTRACT"
+    SOURCE_EXTRACT_COLUMN = "SOURCE_EXTRACT_COLUMN"
+    SOURCE_EXTRACT_JSON_PATH = "SOURCE_EXTRACT_JSON_PATH"
+    TRANSFORM = "TRANSFORM"
+    TRANSFORM_FORMAT = "TRANSFORM_FORMAT"
+    REFERENCE = "REFERENCE"
+    REFERENCE_EXTRACT = "REFERENCE_EXTRACT"
+    REFERENCE_EXTRACT_COLUMN = "REFERENCE_EXTRACT_COLUMN"
+    REFERENCE_EXTRACT_JSON_PATH = "REFERENCE_EXTRACT_JSON_PATH"
+
+
+def handle_field_change(
+    change: FieldEvent,
+    field: Field,
+    key: str,
+    **kwargs,
+):
+    value = st.session_state[key]
+    if change == FieldEvent.NAME:
+        old_name = field.name
+        new_name = value
+        if old_name != new_name:
+            metadata: Metadata = st.session_state[Metadata]
+            metadata.rename_metadata(old_name=old_name, new_name=new_name)
+        field.name = value
+    elif change == FieldEvent.DESCRIPTION:
+        field.description = value
+    elif change == FieldEvent.DATA_TYPE:
+        field.data_types = [value]
+    elif change == FieldEvent.SOURCE:
+        node_type = "field" if "/" in value else "distribution"
+        source = mlc.Source(uid=value, node_type=node_type)
+        field.source = source
+    elif change == FieldEvent.SOURCE_EXTRACT:
+        source = field.source
+        source = _get_source(source, value)
+        field.source = source
+    elif change == FieldEvent.SOURCE_EXTRACT_COLUMN:
+        if not field.source:
+            field.source = mlc.Source(extract=mlc.Extract())
+        field.source.extract = mlc.Extract(column=value)
+    elif change == FieldEvent.SOURCE_EXTRACT_JSON_PATH:
+        if not field.source:
+            field.source = mlc.Source(extract=mlc.Extract())
+        field.source.extract = mlc.Extract(json_path=value)
+    elif change == FieldEvent.TRANSFORM:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform()
+    elif change == TransformType.FORMAT:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform(format=value)
+    elif change == TransformType.JSON_PATH:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform(json_path=value)
+    elif change == TransformType.REGEX:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform(regex=value)
+    elif change == TransformType.REPLACE:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform(replace=value)
+    elif change == TransformType.SEPARATOR:
+        number = kwargs.get("number")
+        if number is not None and number < len(field.source.transforms):
+            field.source.transforms[number] = mlc.Transform(separator=value)
+    elif change == FieldEvent.REFERENCE:
+        node_type = "field" if "/" in value else "distribution"
+        source = mlc.Source(uid=value, node_type=node_type)
+        field.references = source
+    elif change == FieldEvent.REFERENCE_EXTRACT:
+        source = field.references
+        source = _get_source(source, value)
+        field.references = source
+    elif change == FieldEvent.REFERENCE_EXTRACT_COLUMN:
+        if not field.references:
+            field.references = mlc.Source(extract=mlc.Extract())
+        field.references.extract = mlc.Extract(column=value)
+    elif change == FieldEvent.REFERENCE_EXTRACT_JSON_PATH:
+        if not field.references:
+            field.references = mlc.Source(extract=mlc.Extract())
+        field.references.extract = mlc.Extract(json_path=value)

--- a/editor/events/metadata.py
+++ b/editor/events/metadata.py
@@ -1,0 +1,28 @@
+import enum
+
+import streamlit as st
+
+from core.state import Metadata
+
+
+class MetadataEvent(enum.Enum):
+    """Event that triggers a metadata change."""
+
+    NAME = "NAME"
+    DESCRIPTION = "DESCRIPTION"
+    URL = "URL"
+    LICENSE = "LICENSE"
+    CITATION = "CITATION"
+
+
+def handle_metadata_change(event: MetadataEvent, metadata: Metadata, key: str):
+    if event == MetadataEvent.NAME:
+        metadata.name = st.session_state[key]
+    elif event == MetadataEvent.DESCRIPTION:
+        metadata.description = st.session_state[key]
+    elif event == MetadataEvent.LICENSE:
+        metadata.license = st.session_state[key]
+    elif event == MetadataEvent.CITATION:
+        metadata.citation = st.session_state[key]
+    elif event == MetadataEvent.URL:
+        metadata.url = st.session_state[key]

--- a/editor/events/record_sets.py
+++ b/editor/events/record_sets.py
@@ -1,0 +1,29 @@
+import enum
+
+import streamlit as st
+
+from core.state import Metadata
+from core.state import RecordSet
+
+
+class RecordSetEvent(enum.Enum):
+    """Event that triggers a RecordSet change."""
+
+    NAME = "NAME"
+    DESCRIPTION = "DESCRIPTION"
+    IS_ENUMERATION = "IS_ENUMERATION"
+
+
+def handle_record_set_change(event: RecordSetEvent, record_set: RecordSet, key: str):
+    value = st.session_state[key]
+    if event == RecordSetEvent.NAME:
+        old_name = record_set.name
+        new_name = value
+        if old_name != new_name:
+            metadata: Metadata = st.session_state[Metadata]
+            metadata.rename_record_set(old_name=old_name, new_name=new_name)
+        record_set.name = value
+    elif event == RecordSetEvent.DESCRIPTION:
+        record_set.description = value
+    elif event == RecordSetEvent.IS_ENUMERATION:
+        record_set.is_enumeration = value

--- a/editor/events/resources.py
+++ b/editor/events/resources.py
@@ -1,0 +1,41 @@
+import enum
+
+import streamlit as st
+
+from core.state import FileObject
+from core.state import FileSet
+from core.state import Metadata
+
+Resource = FileObject | FileSet
+
+
+class ResourceEvent(enum.Enum):
+    """Event that triggers a resource change."""
+
+    NAME = "NAME"
+    DESCRIPTION = "DESCRIPTION"
+    ENCODING_FORMAT = "ENCODING_FORMAT"
+    SHA256 = "SHA256"
+    CONTENT_SIZE = "CONTENT_SIZE"
+    CONTENT_URL = "CONTENT_URL"
+
+
+def handle_resource_change(event: ResourceEvent, resource: Resource, key: str):
+    value = st.session_state[key]
+    if event == ResourceEvent.NAME:
+        old_name = resource.name
+        new_name = value
+        if old_name != new_name:
+            metadata: Metadata = st.session_state[Metadata]
+            metadata.rename_distribution(old_name=old_name, new_name=new_name)
+        resource.name = value
+    elif event == ResourceEvent.DESCRIPTION:
+        resource.description = value
+    elif event == ResourceEvent.ENCODING_FORMAT:
+        resource.encoding_format = value
+    elif event == ResourceEvent.SHA256:
+        resource.sha256 = value
+    elif event == ResourceEvent.CONTENT_SIZE:
+        resource.content_size = value
+    elif event == ResourceEvent.CONTENT_URL:
+        resource.content_url = value

--- a/editor/views/files.py
+++ b/editor/views/files.py
@@ -15,6 +15,8 @@ from core.state import FileObject
 from core.state import FileSet
 from core.state import Metadata
 from core.state import SelectedResource
+from events.resources import handle_resource_change
+from events.resources import ResourceEvent
 from utils import DF_HEIGHT
 from utils import needed_field
 
@@ -26,34 +28,6 @@ _MANUAL_RESOURCE_TYPE_KEY = "create_manually_type"
 _MANUAL_NAME_KEY = "manual_object_name"
 _MANUAL_DESCRIPTION_KEY = "manual_object_description"
 _MANUAL_SHA256_KEY = "manual_object_sha256"
-
-Resource = FileObject | FileSet
-
-
-class ResourceEvent(enum.Enum):
-    """Event that triggers a resource change."""
-
-    NAME = "NAME"
-    DESCRIPTION = "DESCRIPTION"
-    ENCODING_FORMAT = "ENCODING_FORMAT"
-    SHA256 = "SHA256"
-    CONTENT_SIZE = "CONTENT_SIZE"
-    CONTENT_URL = "CONTENT_URL"
-
-
-def handle_resource_change(event: ResourceEvent, resource: Resource, key: str):
-    if event == ResourceEvent.NAME:
-        resource.name = st.session_state[key]
-    elif event == ResourceEvent.DESCRIPTION:
-        resource.description = st.session_state[key]
-    elif event == ResourceEvent.ENCODING_FORMAT:
-        resource.license = st.session_state[key]
-    elif event == ResourceEvent.SHA256:
-        resource.citation = st.session_state[key]
-    elif event == ResourceEvent.CONTENT_SIZE:
-        resource.url = st.session_state[key]
-    elif event == ResourceEvent.CONTENT_URL:
-        resource.url = st.session_state[key]
 
 
 def render_files():

--- a/editor/views/files.py
+++ b/editor/views/files.py
@@ -1,4 +1,5 @@
-import pandas as pd
+import enum
+
 import streamlit as st
 
 from components.tree import render_tree
@@ -25,6 +26,34 @@ _MANUAL_RESOURCE_TYPE_KEY = "create_manually_type"
 _MANUAL_NAME_KEY = "manual_object_name"
 _MANUAL_DESCRIPTION_KEY = "manual_object_description"
 _MANUAL_SHA256_KEY = "manual_object_sha256"
+
+Resource = FileObject | FileSet
+
+
+class ResourceEvent(enum.Enum):
+    """Event that triggers a resource change."""
+
+    NAME = "NAME"
+    DESCRIPTION = "DESCRIPTION"
+    ENCODING_FORMAT = "ENCODING_FORMAT"
+    SHA256 = "SHA256"
+    CONTENT_SIZE = "CONTENT_SIZE"
+    CONTENT_URL = "CONTENT_URL"
+
+
+def handle_resource_change(event: ResourceEvent, resource: Resource, key: str):
+    if event == ResourceEvent.NAME:
+        resource.name = st.session_state[key]
+    elif event == ResourceEvent.DESCRIPTION:
+        resource.description = st.session_state[key]
+    elif event == ResourceEvent.ENCODING_FORMAT:
+        resource.license = st.session_state[key]
+    elif event == ResourceEvent.SHA256:
+        resource.citation = st.session_state[key]
+    elif event == ResourceEvent.CONTENT_SIZE:
+        resource.url = st.session_state[key]
+    elif event == ResourceEvent.CONTENT_URL:
+        resource.url = st.session_state[key]
 
 
 def render_files():
@@ -178,60 +207,73 @@ def _render_resource_details(selected_file: Resource):
             col.button("Remove", key=f"{key}_url", on_click=delete_line, type="primary")
 
 
-def _render_file_object(key: int, file: FileObject):
-    name = st.text_input(needed_field("Name"), value=file.name, key=f"{key}_name")
-    description = st.text_area(
+def _render_file_object(prefix: int, file: FileObject):
+    key = f"{prefix}_name"
+    st.text_input(
+        needed_field("Name"),
+        value=file.name,
+        key=key,
+        on_change=handle_resource_change,
+        args=(ResourceEvent.NAME, file, key),
+    )
+    key = f"{prefix}_description"
+    st.text_area(
         "Description",
         value=file.description,
         placeholder="Provide a clear description of the file.",
-        key=f"{key}_description",
+        key=key,
+        on_change=handle_resource_change,
+        args=(ResourceEvent.DESCRIPTION, file, key),
     )
-    sha256 = st.text_input(
+    key = f"{prefix}_sha256"
+    st.text_input(
         needed_field("SHA256"),
         value=file.sha256,
         disabled=True,
-        key=f"{key}_sha256",
+        key=key,
+        on_change=handle_resource_change,
+        args=(ResourceEvent.SHA256, file, key),
     )
-    encoding_format = st.text_input(
+    key = f"{prefix}_encoding"
+    st.text_input(
         needed_field("Encoding format"),
         value=file.encoding_format,
         disabled=True,
-        key=f"{key}_encoding",
+        key=key,
+        on_change=handle_resource_change,
+        args=(ResourceEvent.ENCODING_FORMAT, file, key),
     )
     st.markdown("First rows of data:")
     if file.df is not None:
         st.dataframe(file.df, height=DF_HEIGHT)
     else:
         st.text("No rendering possible.")
-    file = FileObject(
-        name=name,
-        description=description,
-        content_url=file.content_url,
-        content_size=file.content_size,
-        encoding_format=encoding_format,
-        sha256=sha256,
-        df=file.df,
+
+
+def _render_file_set(prefix: int, file: FileSet):
+    key = f"{prefix}_name"
+    st.text_input(
+        needed_field("Name"),
+        value=file.name,
+        key=key,
+        on_change=handle_resource_change,
+        args=(ResourceEvent.NAME, file, key),
     )
-    st.session_state[Metadata].update_distribution(key, file)
-
-
-def _render_file_set(key: int, file: FileSet):
-    name = st.text_input(needed_field("Name"), value=file.name, key=f"{key}_name")
-    description = st.text_area(
+    key = f"{prefix}_description"
+    st.text_area(
         "Description",
         value=file.description,
         placeholder="Provide a clear description of the file.",
-        key=f"{key}_description",
+        key=key,
+        on_change=handle_resource_change,
+        args=(ResourceEvent.DESCRIPTION, file, key),
     )
-    encoding_format = st.text_input(
+    key = f"{prefix}_encoding"
+    st.text_input(
         needed_field("Encoding format"),
         value=file.encoding_format,
         disabled=True,
-        key=f"{key}_encoding",
+        key=key,
+        on_change=handle_resource_change,
+        args=(ResourceEvent.ENCODING_FORMAT, file, key),
     )
-    file = FileSet(
-        description=description,
-        encoding_format=encoding_format,
-        name=name,
-    )
-    st.session_state[Metadata].update_distribution(key, file)

--- a/editor/views/metadata.py
+++ b/editor/views/metadata.py
@@ -1,3 +1,5 @@
+import enum
+
 import streamlit as st
 
 from core.state import Metadata
@@ -23,27 +25,50 @@ licenses = [
 ]
 
 
+class MetadataEvent(enum.Enum):
+    """Event that triggers a metadata change."""
+
+    NAME = "NAME"
+    DESCRIPTION = "DESCRIPTION"
+    URL = "URL"
+    LICENSE = "LICENSE"
+    CITATION = "CITATION"
+
+
+def handle_metadata_change(event: MetadataEvent, metadata: Metadata, key: str):
+    if event == MetadataEvent.NAME:
+        metadata.name = st.session_state[key]
+    elif event == MetadataEvent.DESCRIPTION:
+        metadata.description = st.session_state[key]
+    elif event == MetadataEvent.LICENSE:
+        metadata.license = st.session_state[key]
+    elif event == MetadataEvent.CITATION:
+        metadata.citation = st.session_state[key]
+    elif event == MetadataEvent.URL:
+        metadata.url = st.session_state[key]
+
+
 def render_metadata():
     metadata = st.session_state[Metadata]
     try:
         index = licenses.index(metadata.license)
     except ValueError:
         index = None
-    license = st.selectbox(
+    key = "metadata-license"
+    st.selectbox(
         label="License",
+        key=key,
         options=licenses,
         index=index,
+        on_change=handle_metadata_change,
+        args=(MetadataEvent.LICENSE, metadata, key),
     )
-    citation = st.text_area(
+    key = "metadata-citation"
+    st.text_area(
         label="Citation",
+        key=key,
         value=metadata.citation,
         placeholder="@book{\n  title={Title}\n}",
-    )
-    # We fully recreate the session state in order to force the re-rendering.
-    metadata.update_metadata(
-        name=metadata.name,
-        description=metadata.description,
-        license=license,
-        url=metadata.url,
-        citation=citation,
+        on_change=handle_metadata_change,
+        args=(MetadataEvent.CITATION, metadata, key),
     )

--- a/editor/views/metadata.py
+++ b/editor/views/metadata.py
@@ -3,7 +3,8 @@ import enum
 import streamlit as st
 
 from core.state import Metadata
-from utils import needed_field
+from events.metadata import handle_metadata_change
+from events.metadata import MetadataEvent
 
 # List from https://www.kaggle.com/discussions/general/116302.
 licenses = [
@@ -23,29 +24,6 @@ licenses = [
     "CC BY-NC-SA",
     "CC BY-NC-ND",
 ]
-
-
-class MetadataEvent(enum.Enum):
-    """Event that triggers a metadata change."""
-
-    NAME = "NAME"
-    DESCRIPTION = "DESCRIPTION"
-    URL = "URL"
-    LICENSE = "LICENSE"
-    CITATION = "CITATION"
-
-
-def handle_metadata_change(event: MetadataEvent, metadata: Metadata, key: str):
-    if event == MetadataEvent.NAME:
-        metadata.name = st.session_state[key]
-    elif event == MetadataEvent.DESCRIPTION:
-        metadata.description = st.session_state[key]
-    elif event == MetadataEvent.LICENSE:
-        metadata.license = st.session_state[key]
-    elif event == MetadataEvent.CITATION:
-        metadata.citation = st.session_state[key]
-    elif event == MetadataEvent.URL:
-        metadata.url = st.session_state[key]
 
 
 def render_metadata():

--- a/editor/views/overview.py
+++ b/editor/views/overview.py
@@ -1,41 +1,46 @@
-import os
-
 import streamlit as st
 
 from core.state import Metadata
 import mlcroissant as mlc
 from utils import needed_field
+from views.metadata import handle_metadata_change
+from views.metadata import MetadataEvent
 
 
 def render_overview():
     metadata = st.session_state[Metadata]
     col1, col2 = st.columns([1, 1], gap="medium")
     with col1:
-        name = st.text_input(
+        key = "metadata-name"
+        st.text_input(
             label=needed_field("Name"),
+            key=key,
             value=metadata.name,
             placeholder="Dataset",
+            on_change=handle_metadata_change,
+            args=(MetadataEvent.NAME, metadata, key),
         )
-        url = st.text_input(
+        key = "metadata-url"
+        st.text_input(
             label=needed_field("URL"),
+            key=key,
             value=metadata.url,
             placeholder="URL to the dataset.",
+            on_change=handle_metadata_change,
+            args=(MetadataEvent.URL, metadata, key),
         )
-        description = st.text_area(
+        key = "metadata-description"
+        st.text_area(
             label="Description",
+            key=key,
             value=metadata.description,
             placeholder="Provide a clear description of the dataset.",
+            on_change=handle_metadata_change,
+            args=(MetadataEvent.DESCRIPTION, metadata, key),
         )
 
         st.subheader(f"{len(metadata.distribution)} Files")
         st.subheader(f"{len(metadata.record_sets)} Record Sets")
-        metadata.update_metadata(
-            name=name,
-            description=description,
-            license=metadata.license,
-            url=url,
-            citation=metadata.citation,
-        )
     with col2:
         if metadata.name and metadata.url:
             st.header("Croissant File Validation")

--- a/editor/views/record_sets.py
+++ b/editor/views/record_sets.py
@@ -213,7 +213,6 @@ def _render_left_panel():
                 record_set.name = name
                 record_set.description = description
                 record_set.is_enumeration = is_enumeration
-                st.session_state[Metadata].update_record_set(key, record_set)
             names = [field.name for field in record_set.fields]
             descriptions = [field.description for field in record_set.fields]
             # TODO(https://github.com/mlcommons/croissant/issues/350): Allow to display
@@ -290,7 +289,7 @@ def _render_right_panel():
                 key=key,
                 value=field.name,
                 on_change=handle_field_change,
-                args=(ChangeEvent.NAME, record_set_key, field_key, field, key),
+                args=(ChangeEvent.NAME, field, key),
             )
             key = f"{prefix}-description"
             col2.text_input(
@@ -299,7 +298,7 @@ def _render_right_panel():
                 key=key,
                 on_change=handle_field_change,
                 value=field.description,
-                args=(ChangeEvent.DESCRIPTION, record_set_key, field_key, field, key),
+                args=(ChangeEvent.DESCRIPTION, field, key),
             )
             if field.data_types:
                 data_type = field.data_types[0]
@@ -318,7 +317,7 @@ def _render_right_panel():
                 options=DATA_TYPES,
                 key=key,
                 on_change=handle_field_change,
-                args=(ChangeEvent.DATA_TYPE, record_set_key, field_key, field, key),
+                args=(ChangeEvent.DATA_TYPE, field, key),
             )
             possible_sources = _get_possible_sources(metadata)
             render_source(

--- a/editor/views/record_sets.py
+++ b/editor/views/record_sets.py
@@ -85,7 +85,9 @@ def _handle_fields_change(record_set_key: int, record_set: RecordSet):
     data_editor_key = _data_editor_key(record_set_key, record_set)
     result = st.session_state[data_editor_key]
     # `result` has the following structure:
+    # ```
     # {'edited_rows': {1: {}}, 'added_rows': [], 'deleted_rows': []}
+    # ```
     fields = record_set.fields
     for field_key in result["edited_rows"]:
         field = fields[field_key]
@@ -97,7 +99,6 @@ def _handle_fields_change(record_set_key: int, record_set: RecordSet):
                 field.description = new_value
             elif new_field == FieldDataFrame.DATA_TYPE:
                 field.data_types = [new_value]
-        st.session_state[Metadata].update_field(record_set_key, field_key, field)
     for added_row in result["added_rows"]:
         field = Field(
             name=added_row.get(FieldDataFrame.NAME),
@@ -146,7 +147,7 @@ def _render_left_panel():
     record_set: RecordSet
     for key, record_set in enumerate(record_sets):
         title = f"**{record_set.name}** ({len(record_set.fields)} fields)"
-        prefix = f"{record_set.name}-{key}"
+        prefix = f"record-set-{key}"
         with st.expander(title, expanded=False):
             col1, col2 = st.columns([1, 3])
             name = col1.text_input(
@@ -230,7 +231,10 @@ def _render_left_panel():
                 dtype=np.str_,
             )
             data_editor_key = _data_editor_key(key, record_set)
-            st.markdown(needed_field("Fields"))
+            st.markdown(
+                f"{needed_field('Fields')} (add/delete fields by directly editing the"
+                " table)"
+            )
             st.data_editor(
                 fields,
                 use_container_width=True,
@@ -276,7 +280,7 @@ def _render_right_panel():
     record_set_key = selected.record_set_key
     with st.expander("**Fields**", expanded=True):
         for field_key, field in enumerate(record_set.fields):
-            prefix = f"{record_set}-{record_set_key}-{field.name}-{field_key}"
+            prefix = f"{record_set_key}-{field.name}-{field_key}"
             col1, col2, col3 = st.columns([1, 1, 1])
 
             key = f"{prefix}-name"

--- a/editor/views/source.py
+++ b/editor/views/source.py
@@ -4,8 +4,11 @@ from typing import Any
 import streamlit as st
 
 from core.state import Field
-from core.state import Metadata
 from core.state import RecordSet
+from events.fields import ExtractType
+from events.fields import FieldEvent
+from events.fields import handle_field_change
+from events.fields import TransformType
 import mlcroissant as mlc
 from utils import DF_HEIGHT
 from utils import needed_field
@@ -16,19 +19,6 @@ class SourceType:
 
     DISTRIBUTION = "distribution"
     FIELD = "field"
-
-
-class ExtractType:
-    """The type of extraction to perform."""
-
-    COLUMN = "Column"
-    JSON_PATH = "JSON path"
-    FILE_CONTENT = "File content"
-    FILE_NAME = "File name"
-    FILE_PATH = "File path"
-    FILE_FULLPATH = "Full path"
-    FILE_LINES = "Lines in file"
-    FILE_LINE_NUMBERS = "Line numbers in file"
 
 
 EXTRACT_TYPES = [
@@ -43,17 +33,6 @@ EXTRACT_TYPES = [
 ]
 
 
-class TransformType:
-    """The type of transformation to perform."""
-
-    FORMAT = "Apply format"
-    JSON_PATH = "Apply JSON path"
-    REGEX = "Apply regular expression"
-    REPLACE = "Replace"
-    SEPARATOR = "Separator"
-
-
-# TODO(marcenacp): Possible to remove?
 TRANSFORM_TYPES = [
     TransformType.FORMAT,
     TransformType.JSON_PATH,
@@ -126,117 +105,6 @@ def _handle_remove_reference(field):
     field.references = mlc.Source()
 
 
-class ChangeEvent(enum.Enum):
-    """Event that triggers a field change."""
-
-    NAME = "NAME"
-    DESCRIPTION = "DESCRIPTION"
-    DATA_TYPE = "DATA_TYPE"
-    SOURCE = "SOURCE"
-    SOURCE_EXTRACT = "SOURCE_EXTRACT"
-    SOURCE_EXTRACT_COLUMN = "SOURCE_EXTRACT_COLUMN"
-    SOURCE_EXTRACT_JSON_PATH = "SOURCE_EXTRACT_JSON_PATH"
-    TRANSFORM = "TRANSFORM"
-    TRANSFORM_FORMAT = "TRANSFORM_FORMAT"
-    REFERENCE = "REFERENCE"
-    REFERENCE_EXTRACT = "REFERENCE_EXTRACT"
-    REFERENCE_EXTRACT_COLUMN = "REFERENCE_EXTRACT_COLUMN"
-    REFERENCE_EXTRACT_JSON_PATH = "REFERENCE_EXTRACT_JSON_PATH"
-
-
-def _get_source(source: mlc.Source | None, value: Any) -> mlc.Source:
-    if not source:
-        source = mlc.Source(extract=mlc.Extract())
-    if value == ExtractType.COLUMN:
-        source.extract = mlc.Extract(column="")
-    elif value == ExtractType.FILE_CONTENT:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.content)
-    elif value == ExtractType.FILE_NAME:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.filename)
-    elif value == ExtractType.FILE_PATH:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.filepath)
-    elif value == ExtractType.FILE_FULLPATH:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.fullpath)
-    elif value == ExtractType.FILE_LINES:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.lines)
-    elif value == ExtractType.FILE_LINE_NUMBERS:
-        source.extract = mlc.Extract(file_property=mlc.FileProperty.lineNumbers)
-    elif value == ExtractType.JSON_PATH:
-        source.extract = mlc.Extract(json_path="")
-    return source
-
-
-def handle_field_change(
-    change: ChangeEvent,
-    field: Field,
-    key: str,
-    **kwargs,
-):
-    value = st.session_state[key]
-    if change == ChangeEvent.NAME:
-        field.name = value
-    elif change == ChangeEvent.DESCRIPTION:
-        field.description = value
-    elif change == ChangeEvent.DATA_TYPE:
-        field.data_types = [value]
-    elif change == ChangeEvent.SOURCE:
-        node_type = "field" if "/" in value else "distribution"
-        source = mlc.Source(uid=value, node_type=node_type)
-        field.source = source
-    elif change == ChangeEvent.SOURCE_EXTRACT:
-        source = field.source
-        source = _get_source(source, value)
-        field.source = source
-    elif change == ChangeEvent.SOURCE_EXTRACT_COLUMN:
-        if not field.source:
-            field.source = mlc.Source(extract=mlc.Extract())
-        field.source.extract = mlc.Extract(column=value)
-    elif change == ChangeEvent.SOURCE_EXTRACT_JSON_PATH:
-        if not field.source:
-            field.source = mlc.Source(extract=mlc.Extract())
-        field.source.extract = mlc.Extract(json_path=value)
-    elif change == ChangeEvent.TRANSFORM:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform()
-    elif change == TransformType.FORMAT:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform(format=value)
-    elif change == TransformType.JSON_PATH:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform(json_path=value)
-    elif change == TransformType.REGEX:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform(regex=value)
-    elif change == TransformType.REPLACE:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform(replace=value)
-    elif change == TransformType.SEPARATOR:
-        number = kwargs.get("number")
-        if number is not None and number < len(field.source.transforms):
-            field.source.transforms[number] = mlc.Transform(separator=value)
-    elif change == ChangeEvent.REFERENCE:
-        node_type = "field" if "/" in value else "distribution"
-        source = mlc.Source(uid=value, node_type=node_type)
-        field.references = source
-    elif change == ChangeEvent.REFERENCE_EXTRACT:
-        source = field.references
-        source = _get_source(source, value)
-        field.references = source
-    elif change == ChangeEvent.REFERENCE_EXTRACT_COLUMN:
-        if not field.references:
-            field.references = mlc.Source(extract=mlc.Extract())
-        field.references.extract = mlc.Extract(column=value)
-    elif change == ChangeEvent.REFERENCE_EXTRACT_JSON_PATH:
-        if not field.references:
-            field.references = mlc.Source(extract=mlc.Extract())
-        field.references.extract = mlc.Extract(json_path=value)
-
-
 def render_source(
     record_set_key: int,
     record_set: RecordSet,
@@ -258,7 +126,7 @@ def render_source(
         options=[s for s in possible_sources if not s.startswith(record_set.name)],
         key=key,
         on_change=handle_field_change,
-        args=(ChangeEvent.SOURCE, field, key),
+        args=(FieldEvent.SOURCE, field, key),
     )
     if source.node_type == "distribution":
         extract = col2.selectbox(
@@ -267,7 +135,7 @@ def render_source(
             key=f"{prefix}-extract",
             options=EXTRACT_TYPES,
             on_change=handle_field_change,
-            args=(ChangeEvent.SOURCE_EXTRACT, field, key),
+            args=(FieldEvent.SOURCE_EXTRACT, field, key),
         )
         if extract == ExtractType.COLUMN:
             key = f"{prefix}-columnname"
@@ -276,7 +144,7 @@ def render_source(
                 value=source.extract.column,
                 key=key,
                 on_change=handle_field_change,
-                args=(ChangeEvent.SOURCE_EXTRACT_COLUMN, field, key),
+                args=(FieldEvent.SOURCE_EXTRACT_COLUMN, field, key),
             )
         if extract == ExtractType.JSON_PATH:
             key = f"{prefix}-jsonpath"
@@ -285,7 +153,7 @@ def render_source(
                 value=source.extract.json_path,
                 key=key,
                 on_change=handle_field_change,
-                args=(ChangeEvent.SOURCE_EXTRACT_JSON_PATH, field, key),
+                args=(FieldEvent.SOURCE_EXTRACT_JSON_PATH, field, key),
             )
 
     # Transforms
@@ -300,7 +168,7 @@ def render_source(
                 key=key,
                 options=TRANSFORM_TYPES,
                 on_change=handle_field_change,
-                args=(ChangeEvent.TRANSFORM, field, key),
+                args=(FieldEvent.TRANSFORM, field, key),
                 kwargs={"number": number},
             )
             if selected == TransformType.FORMAT:
@@ -404,7 +272,7 @@ def render_references(
             options=[s for s in possible_sources if not s.startswith(record_set.name)],
             key=key,
             on_change=handle_field_change,
-            args=(ChangeEvent.REFERENCE, field, key),
+            args=(FieldEvent.REFERENCE, field, key),
         )
         if references.node_type == "distribution":
             key = f"{key}-extract-references"
@@ -414,7 +282,7 @@ def render_references(
                 key=key,
                 options=EXTRACT_TYPES,
                 on_change=handle_field_change,
-                args=(ChangeEvent.REFERENCE_EXTRACT, field, key),
+                args=(FieldEvent.REFERENCE_EXTRACT, field, key),
             )
             if extract == ExtractType.COLUMN:
                 key = f"{key}-columnname"
@@ -423,7 +291,7 @@ def render_references(
                     value=references.extract.column,
                     key=key,
                     on_change=handle_field_change,
-                    args=(ChangeEvent.REFERENCE_EXTRACT_COLUMN, field, key),
+                    args=(FieldEvent.REFERENCE_EXTRACT_COLUMN, field, key),
                 )
             if extract == ExtractType.JSON_PATH:
                 key = f"{key}-jsonpath"
@@ -432,7 +300,7 @@ def render_references(
                     value=references.extract.json_path,
                     key=key,
                     on_change=handle_field_change,
-                    args=(ChangeEvent.REFERENCE_EXTRACT_JSON_PATH, field, key),
+                    args=(FieldEvent.REFERENCE_EXTRACT_JSON_PATH, field, key),
                 )
         col4.button(
             "✖️",

--- a/editor/views/source.py
+++ b/editor/views/source.py
@@ -168,8 +168,6 @@ def _get_source(source: mlc.Source | None, value: Any) -> mlc.Source:
 
 def handle_field_change(
     change: ChangeEvent,
-    record_set_key: int,
-    field_key: int,
     field: Field,
     key: str,
     **kwargs,
@@ -260,7 +258,7 @@ def render_source(
         options=[s for s in possible_sources if not s.startswith(record_set.name)],
         key=key,
         on_change=handle_field_change,
-        args=(ChangeEvent.SOURCE, record_set_key, field_key, field, key),
+        args=(ChangeEvent.SOURCE, field, key),
     )
     if source.node_type == "distribution":
         extract = col2.selectbox(
@@ -269,7 +267,7 @@ def render_source(
             key=f"{prefix}-extract",
             options=EXTRACT_TYPES,
             on_change=handle_field_change,
-            args=(ChangeEvent.SOURCE_EXTRACT, record_set_key, field_key, field, key),
+            args=(ChangeEvent.SOURCE_EXTRACT, field, key),
         )
         if extract == ExtractType.COLUMN:
             key = f"{prefix}-columnname"
@@ -278,13 +276,7 @@ def render_source(
                 value=source.extract.column,
                 key=key,
                 on_change=handle_field_change,
-                args=(
-                    ChangeEvent.SOURCE_EXTRACT_COLUMN,
-                    record_set_key,
-                    field_key,
-                    field,
-                    key,
-                ),
+                args=(ChangeEvent.SOURCE_EXTRACT_COLUMN, field, key),
             )
         if extract == ExtractType.JSON_PATH:
             key = f"{prefix}-jsonpath"
@@ -293,13 +285,7 @@ def render_source(
                 value=source.extract.json_path,
                 key=key,
                 on_change=handle_field_change,
-                args=(
-                    ChangeEvent.SOURCE_EXTRACT_JSON_PATH,
-                    record_set_key,
-                    field_key,
-                    field,
-                    key,
-                ),
+                args=(ChangeEvent.SOURCE_EXTRACT_JSON_PATH, field, key),
             )
 
     # Transforms
@@ -314,7 +300,7 @@ def render_source(
                 key=key,
                 options=TRANSFORM_TYPES,
                 on_change=handle_field_change,
-                args=(ChangeEvent.TRANSFORM, record_set_key, field_key, field, key),
+                args=(ChangeEvent.TRANSFORM, field, key),
                 kwargs={"number": number},
             )
             if selected == TransformType.FORMAT:
@@ -324,7 +310,7 @@ def render_source(
                     value=transform.format,
                     key=key,
                     on_change=handle_field_change,
-                    args=(selected, record_set_key, field_key, field, key),
+                    args=(selected, field, key),
                     kwargs={"number": number, "type": "format"},
                 )
             elif selected == TransformType.JSON_PATH:
@@ -334,7 +320,7 @@ def render_source(
                     value=transform.json_path,
                     key=key,
                     on_change=handle_field_change,
-                    args=(selected, record_set_key, field_key, field, key),
+                    args=(selected, field, key),
                     kwargs={"number": number, "type": "format"},
                 )
             elif selected == TransformType.REGEX:
@@ -344,7 +330,7 @@ def render_source(
                     value=transform.regex,
                     key=key,
                     on_change=handle_field_change,
-                    args=(selected, record_set_key, field_key, field, key),
+                    args=(selected, field, key),
                     kwargs={"number": number, "type": "format"},
                 )
             elif selected == TransformType.REPLACE:
@@ -354,7 +340,7 @@ def render_source(
                     value=transform.replace,
                     key=key,
                     on_change=handle_field_change,
-                    args=(selected, record_set_key, field_key, field, key),
+                    args=(selected, field, key),
                     kwargs={"number": number, "type": "format"},
                 )
             elif selected == TransformType.SEPARATOR:
@@ -364,7 +350,7 @@ def render_source(
                     value=transform.separator,
                     key=key,
                     on_change=handle_field_change,
-                    args=(selected, record_set_key, field_key, field, key),
+                    args=(selected, field, key),
                     kwargs={"number": number, "type": "format"},
                 )
 
@@ -418,7 +404,7 @@ def render_references(
             options=[s for s in possible_sources if not s.startswith(record_set.name)],
             key=key,
             on_change=handle_field_change,
-            args=(ChangeEvent.REFERENCE, record_set_key, field_key, field, key),
+            args=(ChangeEvent.REFERENCE, field, key),
         )
         if references.node_type == "distribution":
             key = f"{key}-extract-references"
@@ -428,13 +414,7 @@ def render_references(
                 key=key,
                 options=EXTRACT_TYPES,
                 on_change=handle_field_change,
-                args=(
-                    ChangeEvent.REFERENCE_EXTRACT,
-                    record_set_key,
-                    field_key,
-                    field,
-                    key,
-                ),
+                args=(ChangeEvent.REFERENCE_EXTRACT, field, key),
             )
             if extract == ExtractType.COLUMN:
                 key = f"{key}-columnname"
@@ -443,13 +423,7 @@ def render_references(
                     value=references.extract.column,
                     key=key,
                     on_change=handle_field_change,
-                    args=(
-                        ChangeEvent.REFERENCE_EXTRACT_COLUMN,
-                        record_set_key,
-                        field_key,
-                        field,
-                        key,
-                    ),
+                    args=(ChangeEvent.REFERENCE_EXTRACT_COLUMN, field, key),
                 )
             if extract == ExtractType.JSON_PATH:
                 key = f"{key}-jsonpath"
@@ -458,13 +432,7 @@ def render_references(
                     value=references.extract.json_path,
                     key=key,
                     on_change=handle_field_change,
-                    args=(
-                        ChangeEvent.REFERENCE_EXTRACT_JSON_PATH,
-                        record_set_key,
-                        field_key,
-                        field,
-                        key,
-                    ),
+                    args=(ChangeEvent.REFERENCE_EXTRACT_JSON_PATH, field, key),
                 )
         col4.button(
             "✖️",

--- a/editor/views/wizard.py
+++ b/editor/views/wizard.py
@@ -32,17 +32,13 @@ RECORD_SETS = "RecordSets"
 def render_editor():
     tab1, tab2, tab3, tab4 = st.tabs([OVERVIEW, METADATA, RESOURCES, RECORD_SETS])
 
+    with tab1:
+        render_overview()
     with tab2:
         render_metadata()
     with tab3:
         render_files()
     with tab4:
         render_record_sets()
-    with tab1:
-        # this happens last so that all other state changes happen first,
-        # before validation, but still appears as the first tab
-        # this is pretty much a limitation of streamlit as it doesn't allow
-        # callback responses to changes in st.session_state
-        render_overview()
     render_download_button()
     save_current_project()


### PR DESCRIPTION
All events were gathered in the `events/` folder.