### PR TITLE
Do not display errors while the user did not start editing.

### DIFF
--- a/editor/app.py
+++ b/editor/app.py
@@ -17,6 +17,7 @@ st.set_page_config(page_title="Croissant Editor", page_icon="🥐", layout="wide
 col1, col2 = st.columns([10, 1])
 col1.header("Croissant Editor")
 if st.session_state[CurrentStep] != CurrentStep.splash:
+    col2.write("\n")  # Vertical box to shift the button menu
     col2.button("Menu", on_click=_back_to_menu)
 
 

--- a/editor/core/constants.py
+++ b/editor/core/constants.py
@@ -1,0 +1,10 @@
+from etils import epath
+
+import mlcroissant as mlc
+
+EDITOR_CACHE: epath.Path = mlc.constants.CROISSANT_CACHE / "editor"
+PAST_PROJECTS_PATH: epath.Path = EDITOR_CACHE / "projects"
+PROJECT_FOLDER_PATTERN = "%Y%m%d%H%M%S%f"
+
+
+DF_HEIGHT = 150

--- a/editor/core/past_projects.py
+++ b/editor/core/past_projects.py
@@ -4,83 +4,30 @@ import shutil
 import time
 
 from etils import epath
+import streamlit as st
 
-import mlcroissant as mlc
-
-from .state import Metadata
-
-PREVIOUS_METADATA_DIRECTORY: str = mlc.constants.CROISSANT_CACHE / "previously_loaded"
-MAX_PREVIOUS_PROJECTS: int = 10
-
-# super simple:
-# Metadata, creation date, last modified date
-projects: list[list[Metadata, int, int]] = []
-
-loaded_project_index: int | None = None
-
-loaded: bool = False
+from core.constants import PAST_PROJECTS_PATH
+from core.state import CurrentProject
+from core.state import Metadata
 
 
-# inital load up of metadata file
-def load_past_projects() -> list[Metadata]:
-    global loaded
-    global projects
-    if not loaded:
-        os.makedirs(PREVIOUS_METADATA_DIRECTORY, exist_ok=True)
-        for item in os.listdir(PREVIOUS_METADATA_DIRECTORY):
-            try:
-                filename = PREVIOUS_METADATA_DIRECTORY / item / "metadata"
-                with open(filename, "rb+") as file:
-                    projects.append([
-                        pickle.loads(file.read()),
-                        float(item),
-                        os.path.getmtime(filename),
-                    ])
-            except:
-                # wasn't a directory or was malformed, either way, skip it
-                pass
-        # order projects by last modified time
-        projects = sorted(projects, key=lambda p: p[2], reverse=True)
-        loaded = True
-    return projects
+def load_past_projects_paths() -> list[epath.Path]:
+    PAST_PROJECTS_PATH.mkdir(parents=True, exist_ok=True)
+    return sorted(list(PAST_PROJECTS_PATH.iterdir()), reverse=True)
 
 
-# move loaded project to the front so we can see it
-def loaded_project(index: int) -> None:
-    global loaded_project_index
-    # bring selected item to the front of the list
-    projects[index][2] = time.time()
-    projects.insert(0, projects.pop(index))
-    os.utime(PREVIOUS_METADATA_DIRECTORY / str(projects[index][1]) / "metadata")
-    loaded_project_index = index
+def _pickle_file(path: epath.Path) -> epath.Path:
+    return path / ".metadata.pkl"
 
 
-def remove_last_project():
-    shutil.rmtree(PREVIOUS_METADATA_DIRECTORY / str(projects[-1][1]))
+def save_current_project():
+    metadata = st.session_state[Metadata]
+    project = st.session_state[CurrentProject]
+    project.path.mkdir(parents=True, exist_ok=True)
+    with _pickle_file(project.path).open("wb") as file:
+        pickle.dump(metadata, file)
 
 
-# run if a new croissant file is created, or if we load a new file
-def add_new_project(metadata: Metadata) -> None:
-    projects.insert(0, [metadata, time.time(), time.time()])
-
-    new_dir = PREVIOUS_METADATA_DIRECTORY / str(projects[0][1])
-    os.makedirs(new_dir, exist_ok=True)
-
-    with open(new_dir / "metadata", "wb") as file:
-        file.write(pickle.dumps(metadata))
-
-    # check to see if we have more than 10 previous projects, remove older ones
-    if len(projects) > MAX_PREVIOUS_PROJECTS:
-        remove_last_project()
-    # load this project
-    loaded_project(0)
-
-
-def save_current_project() -> None:
-    with open(
-        PREVIOUS_METADATA_DIRECTORY
-        / str(projects[loaded_project_index][1])
-        / "metadata.json",
-        "wb",
-    ) as file:
-        file.write(pickle.dumps(projects[loaded_project_index][0]))
+def open_project(path: epath.Path) -> Metadata:
+    with _pickle_file(path).open("rb") as file:
+        return pickle.load(file)

--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -6,11 +6,14 @@ In the future, this could be the serialization format between front and back.
 from __future__ import annotations
 
 import dataclasses
-import enum
+import datetime
 from typing import Any
 
+from etils import epath
 import pandas as pd
 
+from core.constants import PAST_PROJECTS_PATH
+from core.constants import PROJECT_FOLDER_PATTERN
 import mlcroissant as mlc
 
 
@@ -30,6 +33,18 @@ class CurrentStep:
 
     splash = "splash"
     editor = "editor"
+
+
+@dataclasses.dataclass
+class CurrentProject:
+    """The selected project."""
+
+    path: epath.Path
+
+    @classmethod
+    def create_new(cls) -> CurrentProject:
+        timestamp = datetime.datetime.now().strftime(PROJECT_FOLDER_PATTERN)
+        return CurrentProject(path=PAST_PROJECTS_PATH / timestamp)
 
 
 class SelectedResource:

--- a/editor/cypress/e2e/loadCroissant.cy.js
+++ b/editor/cypress/e2e/loadCroissant.cy.js
@@ -47,10 +47,10 @@ describe('Editor loads Croissant without Error', () => {
     
     cy.get('[data-testid="stException"]').should('not.exist')
 
-    cy.get('button').contains('Export').click()
+    cy.get('button').contains('Export').should('exist').should('be.visible').click({force: true})
     cy.fixture('titanic.json').then((fileContent) => {
       const downloadsFolder = Cypress.config("downloadsFolder");
-      cy.readFile(path.join(downloadsFolder, "croissant.json"))
+      cy.readFile(path.join(downloadsFolder, "croissant-titanic.json"))
       .then((downloadedFile) => {
         downloadedFile = JSON.stringify(downloadedFile)
         return downloadedFile

--- a/editor/cypress/e2e/renameDistribution.cy.js
+++ b/editor/cypress/e2e/renameDistribution.cy.js
@@ -26,7 +26,7 @@ describe('Renaming of FileObjects/FileSets/RecordSets/Fields.', () => {
       // Click on genders.csv
       getBody().contains('genders.csv').click()
     })
-    cy.get('input[aria-label="Name:red[*]"][value="genders.csv"]').should('be.visible').type('{selectall}{backspace}the-new-name{enter}')
+    cy.get('input[aria-label="Name:red[*]"][value="genders.csv"]').type('{selectall}{backspace}the-new-name{enter}')
 
     cy.get('button').contains('RecordSets').click()
     cy.contains('genders').click()

--- a/editor/events/fields.py
+++ b/editor/events/fields.py
@@ -83,7 +83,7 @@ def handle_field_change(
         new_name = value
         if old_name != new_name:
             metadata: Metadata = st.session_state[Metadata]
-            metadata.rename_metadata(old_name=old_name, new_name=new_name)
+            metadata.rename_field(old_name=old_name, new_name=new_name)
         field.name = value
     elif change == FieldEvent.DESCRIPTION:
         field.description = value

--- a/editor/requirements.txt
+++ b/editor/requirements.txt
@@ -6,3 +6,4 @@ pytest
 rdflib
 requests
 streamlit
+streamlit-nested-layout

--- a/editor/utils.py
+++ b/editor/utils.py
@@ -1,24 +1,20 @@
-DF_HEIGHT = 150
-
 import streamlit as st
 
+from core.state import CurrentProject
 from core.state import CurrentStep
 from core.state import Metadata
 from core.state import SelectedRecordSet
 from core.state import SelectedResource
 import mlcroissant as mlc
 
-EDITOR_CACHE = mlc.constants.CROISSANT_CACHE / "editor"
-LOADED_CROISSANT = EDITOR_CACHE / "loaded_croissant"
-
 
 def needed_field(text: str) -> str:
     return f"{text}:red[*]"
 
 
-def set_form_step(action, step=None):
+def jump_to(step: str):
     """Maintains the user's location within the editor."""
-    if action == "Jump" and step is not None:
+    if step is not None:
         st.session_state[CurrentStep] = step
 
 
@@ -40,6 +36,9 @@ def init_state(force=False):
     if SelectedResource not in st.session_state or force:
         st.session_state[SelectedRecordSet] = None
 
+    if CurrentProject not in st.session_state or force:
+        st.session_state[CurrentProject] = CurrentProject.create_new()
+
     # Uncomment those lines if you work locally in order to avoid clicks at each reload.
     # And comment all previous lines in `init_state`.
     # if mlc.Dataset not in st.session_state or force:
@@ -50,3 +49,5 @@ def init_state(force=False):
     #     )
     # if CurrentStep not in st.session_state or force:
     #     st.session_state[CurrentStep] = CurrentStep.editor
+    # if CurrentProject not in st.session_state or force:
+    #     st.session_state[CurrentProject] = CurrentProject.create_new()

--- a/editor/views/files.py
+++ b/editor/views/files.py
@@ -3,6 +3,7 @@ import enum
 import streamlit as st
 
 from components.tree import render_tree
+from core.constants import DF_HEIGHT
 from core.files import file_from_form
 from core.files import file_from_upload
 from core.files import file_from_url
@@ -17,7 +18,6 @@ from core.state import Metadata
 from core.state import SelectedResource
 from events.resources import handle_resource_change
 from events.resources import ResourceEvent
-from utils import DF_HEIGHT
 from utils import needed_field
 
 Resource = FileObject | FileSet

--- a/editor/views/load.py
+++ b/editor/views/load.py
@@ -3,11 +3,11 @@ import os
 from etils import epath
 import streamlit as st
 
-from core.past_projects import add_new_project
+from core.past_projects import save_current_project
 from core.state import CurrentStep
 from core.state import Metadata
 import mlcroissant as mlc
-from utils import set_form_step
+from utils import jump_to
 
 
 def render_load():
@@ -26,8 +26,8 @@ def render_load():
                 outfile.write(file_cont)
             dataset = mlc.Dataset(newfile_name)
             st.session_state[Metadata] = Metadata.from_canonical(dataset.metadata)
-            set_form_step("Jump", CurrentStep.editor)
-            add_new_project(st.session_state[Metadata])
+            jump_to(CurrentStep.editor)
+            save_current_project()
             st.rerun()
         except mlc.ValidationError as e:
             st.warning(e)

--- a/editor/views/overview.py
+++ b/editor/views/overview.py
@@ -8,7 +8,7 @@ from views.metadata import MetadataEvent
 
 
 def render_overview():
-    metadata = st.session_state[Metadata]
+    metadata: Metadata = st.session_state[Metadata]
     col1, col2 = st.columns([1, 1], gap="medium")
     with col1:
         key = "metadata-name"
@@ -42,7 +42,8 @@ def render_overview():
         st.subheader(f"{len(metadata.distribution)} Files")
         st.subheader(f"{len(metadata.record_sets)} Record Sets")
     with col2:
-        if metadata.name and metadata.url:
+        user_started_editing = metadata.record_sets or metadata.distribution
+        if user_started_editing:
             st.header("Croissant File Validation")
             try:
                 issues = metadata.to_canonical().issues

--- a/editor/views/overview.py
+++ b/editor/views/overview.py
@@ -44,19 +44,19 @@ def render_overview():
     with col2:
         user_started_editing = metadata.record_sets or metadata.distribution
         if user_started_editing:
-            st.header("Croissant File Validation")
+            st.subheader("Croissant File Validation")
             try:
                 issues = metadata.to_canonical().issues
                 if issues.errors:
-                    st.subheader("Errors:")
+                    st.markdown("##### Errors:")
                     for error in issues.errors:
                         st.write(error)
                 if issues.warnings:
-                    st.subheader("Warnings:")
+                    st.markdown("##### Warnings:")
                     for warning in issues.warnings:
                         st.write(warning)
                 if not issues.errors and not issues.warnings:
                     st.write("No validation issues detected!")
             except mlc.ValidationError as exception:
-                st.subheader("Errors:")
+                st.markdown("##### Errors:")
                 st.write(str(exception))

--- a/editor/views/side_buttons.py
+++ b/editor/views/side_buttons.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
 from core.state import CurrentStep
-from utils import set_form_step
+from utils import jump_to
 
 
 def render_side_buttons():
@@ -13,22 +13,22 @@ def render_side_buttons():
 
         st.button(
             "Metadata",
-            on_click=set_form_step,
-            args=["Jump", CurrentStep.editor],
+            on_click=jump_to,
+            args=[CurrentStep.editor],
             type=button_type("metadata"),
             use_container_width=True,
         )
         st.button(
             "Files",
-            on_click=set_form_step,
-            args=["Jump", CurrentStep.editor],
+            on_click=jump_to,
+            args=[CurrentStep.editor],
             type=button_type("files"),
             use_container_width=True,
         )
         st.button(
             "RecordSets",
-            on_click=set_form_step,
-            args=["Jump", CurrentStep.editor],
+            on_click=jump_to,
+            args=[CurrentStep.editor],
             type=button_type("recordsets"),
             use_container_width=True,
         )

--- a/editor/views/source.py
+++ b/editor/views/source.py
@@ -10,7 +10,6 @@ from events.fields import FieldEvent
 from events.fields import handle_field_change
 from events.fields import TransformType
 import mlcroissant as mlc
-from utils import DF_HEIGHT
 from utils import needed_field
 
 

--- a/editor/views/splash.py
+++ b/editor/views/splash.py
@@ -1,12 +1,12 @@
 import streamlit as st
 
-from core.past_projects import add_new_project
+from core.state import CurrentProject
 from core.state import CurrentStep
 from core.state import Metadata
-from utils import set_form_step
+from utils import jump_to
 from views.load import render_load
 from views.previous_files import render_previous_files
-from views.side_buttons import set_form_step
+from views.side_buttons import jump_to
 
 
 def render_splash():
@@ -17,10 +17,9 @@ def render_splash():
         with st.expander("**Create from scratch**", expanded=True):
 
             def create_new_croissant():
-                new_meta = Metadata()
-                st.session_state[Metadata] = new_meta
-                add_new_project(new_meta)
-                set_form_step("Jump", CurrentStep.editor)
+                st.session_state[Metadata] = Metadata()
+                st.session_state[CurrentProject] = CurrentProject.create_new()
+                jump_to(CurrentStep.editor)
 
             st.button(
                 "Create",

--- a/editor/views/wizard.py
+++ b/editor/views/wizard.py
@@ -1,6 +1,7 @@
 import json
 
 import streamlit as st
+import streamlit_nested_layout  # Do not remove this allows nesting columns.
 
 from core.past_projects import save_current_project
 from core.state import Metadata
@@ -11,16 +12,18 @@ from views.overview import render_overview
 from views.record_sets import render_record_sets
 
 
-def render_download_button():
+def render_export_button(col):
+    metadata: Metadata = st.session_state[Metadata]
     try:
-        st.download_button(
+        col.download_button(
             "Export",
-            file_name="croissant.json",
+            file_name=f"croissant-{metadata.name}.json",
             type="primary",
-            data=json.dumps(st.session_state[Metadata].to_canonical().to_json()),
+            data=json.dumps(metadata.to_canonical().to_json()),
+            help="Export the Croissant JSON-LD",
         )
     except mlc.ValidationError as exception:
-        st.download_button("Export", disabled=True, data="")
+        col.download_button("Export", disabled=True, data="", help=str(exception))
 
 
 OVERVIEW = "Overview"
@@ -30,7 +33,9 @@ RECORD_SETS = "RecordSets"
 
 
 def render_editor():
-    tab1, tab2, tab3, tab4 = st.tabs([OVERVIEW, METADATA, RESOURCES, RECORD_SETS])
+    col1, col2 = st.columns([10, 1])
+    render_export_button(col2)
+    tab1, tab2, tab3, tab4 = col1.tabs([OVERVIEW, METADATA, RESOURCES, RECORD_SETS])
 
     with tab1:
         render_overview()
@@ -40,5 +45,4 @@ def render_editor():
         render_files()
     with tab4:
         render_record_sets()
-    render_download_button()
     save_current_project()

--- a/editor/views/wizard.py
+++ b/editor/views/wizard.py
@@ -17,7 +17,7 @@ def render_export_button(col):
     try:
         col.download_button(
             "Export",
-            file_name=f"croissant-{metadata.name}.json",
+            file_name=f"croissant-{metadata.name.lower()}.json",
             type="primary",
             data=json.dumps(metadata.to_canonical().to_json()),
             help="Export the Croissant JSON-LD",


### PR DESCRIPTION
- Do not display errors while the user did not start editing.
- Position the Export button where it should be positioned.
- Remove bugs related to indices.