### PR TITLE
!cd -> %cd

### DIFF
--- a/python/mlcroissant/recipes/introduction.ipynb
+++ b/python/mlcroissant/recipes/introduction.ipynb
@@ -54,7 +54,7 @@
         "\n",
         "!git clone https://github.com/mlcommons/croissant.git",
         "\n",
-        "!cd croissant/python/mlcroissant",
+        "%cd croissant/python/mlcroissant",
         "\n",
         "!pip install -e .[git]",
         "\n"


### PR DESCRIPTION
see https://stackoverflow.com/questions/48298146/changing-directory-in-google-colab-breaking-out-of-the-python-interpreter

!cd does not change the working directory, which means the pip package does not get installed, which means the colab demo cannot start