### PR TITLE
add link to kaggle page where the license names from the dropdown are resolved as the dropdown differs from other conventions, check for example https://creativecommons.org/licenses/by/4.0/legalcode

### DIFF
--- a/editor/views/metadata.py
+++ b/editor/views/metadata.py
@@ -35,6 +35,7 @@ def render_metadata():
     key = "metadata-license"
     st.selectbox(
         label="License",
+        help="More information on license names and meaning can be found [here](https://www.kaggle.com/discussions/general/116302).",
         key=key,
         options=licenses,
         index=index,


### PR DESCRIPTION
when i create a new dataset i want to be able to quickly understand the license names.

the dropdown terms

```
# List from https://www.kaggle.com/discussions/general/116302.
licenses = [
    "Other",
    "Public Domain",
    "Public",
    "CC-0",
    "PDDL",
    "CC-BY",
    "CDLA-Permissive-1.0",
    "ODC-BY",
    "CC-BY-SA",
    "CDLA-Sharing-1.0",
    "ODC-ODbL",
    "CC BY-NC",
    "CC BY-ND",
    "CC BY-NC-SA",
    "CC BY-NC-ND",
]
```

differ from other conventions.

for example CC-BY 4 (https://creativecommons.org/licenses/by/4.0/legalcode) is often used, missing from the dropdown, but when i go to the kaggle link i understand that whats in the dropdown as CC-BY corresponds to CC-BY 4.

possible fix: add a help tag containing explanation link to the st.selectbox for the metadata.