### PR TITLE
Do not cache user in backend.

### DIFF
--- a/editor/app.py
+++ b/editor/app.py
@@ -7,7 +7,7 @@ from core.constants import OAUTH_STATE
 from core.constants import REDIRECT_URI
 from core.query_params import get_project_timestamp
 from core.state import CurrentProject
-from core.state import get_cached_user
+from core.state import get_user
 from core.state import User
 from utils import init_state
 from views.splash import render_splash
@@ -19,7 +19,7 @@ col1.header("Croissant Editor")
 
 init_state()
 
-user = get_cached_user()
+user = get_user()
 
 if OAUTH_CLIENT_ID and not user:
     query_params = st.experimental_get_query_params()
@@ -31,8 +31,7 @@ if OAUTH_CLIENT_ID and not user:
         try:
             st.session_state[User] = User.connect(code)
             # Clear the cache to force retrieving the new user.
-            get_cached_user.clear()
-            get_cached_user()
+            get_user()
         except:
             raise
         finally:
@@ -56,7 +55,6 @@ def _back_to_menu():
 def _logout():
     """Logs the user out."""
     st.cache_data.clear()
-    get_cached_user.clear()
     st.session_state[User] = None
     _back_to_menu()
 

--- a/editor/core/past_projects.py
+++ b/editor/core/past_projects.py
@@ -8,12 +8,12 @@ from core.constants import PAST_PROJECTS_PATH
 from core.query_params import set_project
 from core.state import CurrentProject
 from core.state import FileObject
-from core.state import get_cached_user
+from core.state import get_user
 from core.state import Metadata
 
 
 def load_past_projects_paths() -> list[epath.Path]:
-    user = get_cached_user()
+    user = get_user()
     past_projects_path = PAST_PROJECTS_PATH(user)
     past_projects_path.mkdir(parents=True, exist_ok=True)
     return sorted(list(past_projects_path.iterdir()), reverse=True)

--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -83,9 +83,8 @@ class User:
         )
 
 
-@st.cache_data(ttl=datetime.timedelta(hours=1))
-def get_cached_user():
-    """Caches user in session_state."""
+def get_user():
+    """Get user from session_state."""
     return st.session_state.get(User)
 
 
@@ -102,7 +101,7 @@ class CurrentProject:
 
     @classmethod
     def from_timestamp(cls, timestamp: str) -> CurrentProject | None:
-        user = get_cached_user()
+        user = get_user()
         if user is None and OAUTH_CLIENT_ID:
             return None
         else:


### PR DESCRIPTION
Reason: In Streamlit, cache is not handled per session, but cache is common to all users.