### PR TITLE
GitHub action to automatically publish new releases to PyPi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,49 @@
+# These workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build distribution
+      run: |
+        cd mlcube
+        python setup.py sdist bdist_wheel
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        verify-metadata: true
+        skip-existing: true
+        packages-dir: mlcube/dist/
+        repository-url: https://upload.pypi.org/legacy/
+        verbose: true
+      env:
+        LOGLEVEL: DEBUG
+
+#  dispatch:
+#    needs: deploy
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Repository Dispatch
+#        uses: peter-evans/repository-dispatch@v2
+#        with:
+#          token: ${{ secrets.MLCOMMONS_REPO_ACCESS }}
+#          repository: mlcommons/mlcube
+#          event-type: publish-runners

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,15 +24,15 @@ jobs:
         pip install setuptools wheel twine
     - name: Build distribution
       run: |
-        cd mlcube
-        python setup.py sdist bdist_wheel
+        cd python/mlcroissant
+        python -m build
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         verify-metadata: true
         skip-existing: true
-        packages-dir: mlcube/dist/
-        repository-url: https://upload.pypi.org/legacy/
+        packages-dir: python/mlcroissant/dist
+        repository-url: https://test.pypi.org/legacy/
         verbose: true
       env:
         LOGLEVEL: DEBUG

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -32,7 +32,7 @@ jobs:
         verify-metadata: true
         skip-existing: true
         packages-dir: python/mlcroissant/dist
-        repository-url: https://test.pypi.org/legacy/
+        repository-url: https://upload.pypi.org/legacy/
         verbose: true
       env:
         LOGLEVEL: DEBUG

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel twine build
     - name: Build distribution
       run: |
         cd python/mlcroissant

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -37,13 +37,5 @@ jobs:
       env:
         LOGLEVEL: DEBUG
 
-#  dispatch:
-#    needs: deploy
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Repository Dispatch
-#        uses: peter-evans/repository-dispatch@v2
-#        with:
-#          token: ${{ secrets.MLCOMMONS_REPO_ACCESS }}
-#          repository: mlcommons/mlcube
-#          event-type: publish-runners
+# If you wish to publish the package to multiple repositories at once, get inspiration from
+# https://github.com/mlcommons/mlcube/blob/master/.github/workflows/python-publish.yml.

--- a/python/mlcroissant/README.md
+++ b/python/mlcroissant/README.md
@@ -130,31 +130,10 @@ This will:
 1. print extra information, like the generated nodes;
 2. save the generated structure graph to a folder indicated in the logs.
 
-## Publishing wheels
+## Publishing packages
 
-Publishing is done manually.
-We are in the process of setting up an automatic deployment with GitHub Actions.
+To publish a package,
 
 1. Bump the version in `croissant/python/mlcroissant/pyproject.toml`.
-1. Configure Twine locally ([full tutorial](https://packaging.python.org/en/latest/tutorials/packaging-projects/)):
-```
-[distutils]
-  index-servers =
-    pypi
-    mlcroissant
+2. Publish a release in GitHub. The workflow script `python-publish.yml` will trigger and publish the package to PyPI.
 
-[pypi]
-username =
-password =
-
-[mlcroissant]
-repository = https://upload.pypi.org/legacy/
-username = __token__
-password = # generate the password on https://pypi.org/manage/account/token/
-```
-1. Build locally and push to PyPI:
-```bash
-rm -rf dist/
-python -m build
-python -m twine upload --repository mlcroissant dist/*
-```


### PR DESCRIPTION
Hi, Bruno Ferreira from MLCommons Systems here.  This GitHub action should trigger whenever a new release is created and automatically build and publish the package to PyPi. The build commands use Twine to build the package.