### PR TITLE
Only check hashes for Croissant>0.8.

### DIFF
--- a/datasets/1.0/coco2014-mini/metadata.json
+++ b/datasets/1.0/coco2014-mini/metadata.json
@@ -53,7 +53,7 @@
       "contentSize": " B",
       "contentUrl": "data/train2014.zip",
       "encodingFormat": "application/zip",
-      "sha256": "sha256"
+      "sha256": "d010037fee9416bdcc187a37a4aec7bef798316147da2753bd86e78fc0d469a5"
     },
     {
       "@type": "sc:FileSet",
@@ -68,14 +68,14 @@
       "contentSize": " B",
       "contentUrl": "data/captions_train2014.json",
       "encodingFormat": "application/json",
-      "sha256": "sha256"
+      "sha256": "6f3755cb987413021018525cbb4c484d696ff41269e6b0b43c5f63eaf576e09f"
     },
     {
       "@type": "sc:FileObject",
       "name": "bbox_annotations-files",
       "contentUrl": "data/instances_train2014.json",
       "encodingFormat": "application/json",
-      "sha256": "sha256"
+      "sha256": "df2760cf1d55e37b9cde91499286a3cac52efc31d95a9d21ba34dbbbcf693654"
     }
   ],
   "recordSet": [

--- a/datasets/1.0/pass-mini/metadata.json
+++ b/datasets/1.0/pass-mini/metadata.json
@@ -50,21 +50,21 @@
       "name": "metadata",
       "contentUrl": "data/pass_metadata.csv",
       "encodingFormat": "text/csv",
-      "sha256": "foo"
+      "sha256": "22f083fb90d4d6d44c5492481c99049a960cf1dcbae71020bd87b94cb4141dae"
     },
     {
       "@type": "sc:FileObject",
       "name": "pass0",
       "contentUrl": "data/PASS.0.tar",
       "encodingFormat": "application/x-tar",
-      "sha256": "bar"
+      "sha256": "7e0ae9fd44a42e2b2f647ded8073b380239c2505862fd7eb1eff17430c52a60e"
     },
     {
       "@type": "sc:FileObject",
       "name": "pass1",
       "contentUrl": "data/PASS.1.tar",
       "encodingFormat": "application/x-tar",
-      "sha256": "bar"
+      "sha256": "a7dfd02caa9eba288e3d60083d2fdeb41c6f8aca771362059b1999b9fdf7ffb2"
     },
     {
       "@type": "sc:FileSet",

--- a/datasets/1.0/recipes/file_object_in_zip.json
+++ b/datasets/1.0/recipes/file_object_in_zip.json
@@ -48,7 +48,7 @@
       "name": "zip_with_csv",
       "contentUrl": "data/zip_with_csv.zip",
       "encodingFormat": "application/zip",
-      "sha256": "85c13a7e6940a8376f2448ed6078d4fa407ae33c7839e6d041a0e34413366792"
+      "sha256": "409b80b15f540661197ae22b78cda2f5cd71f336379f5c9cd1a6b4fc6abe74bd"
     },
     {
       "@type": "sc:FileObject",

--- a/datasets/1.0/simple-parquet/metadata.json
+++ b/datasets/1.0/simple-parquet/metadata.json
@@ -49,7 +49,7 @@
       "name": "dataframe",
       "contentUrl": "data/dataframe.parquet",
       "encodingFormat": "application/x-parquet",
-      "sha256": "SHA256"
+      "sha256": "ac97b111a16d2b29cd2ea006a50d6c286cb7e05f89d942192b6d8df0b4198121"
     }
   ],
   "recordSet": [

--- a/datasets/1.0/titanic/metadata.json
+++ b/datasets/1.0/titanic/metadata.json
@@ -62,7 +62,7 @@
       "contentSize": "117743 B",
       "contentUrl": "data/genders.csv",
       "encodingFormat": "text/csv",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
+      "sha256": "3b0d1ce9ffb5224626105c50a0f9e5fbf941bcbcd913e5567aba25936333c3b8"
     },
     {
       "@type": "sc:FileObject",
@@ -71,7 +71,7 @@
       "contentSize": "117743 B",
       "contentUrl": "data/embarkation_ports.csv",
       "encodingFormat": "text/csv",
-      "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737"
+      "sha256": "38dc364ac098f39ecb5c108c8911ef47a7256a146aef3c26c85e7cc01efdd047"
     }
   ],
   "recordSet": [

--- a/python/mlcroissant/mlcroissant/_src/datasets.py
+++ b/python/mlcroissant/mlcroissant/_src/datasets.py
@@ -93,7 +93,11 @@ class Dataset:
     def records(self, record_set: str) -> Records:
         """Accesses all records in `record_set` if it exists."""
         if not any(rs for rs in self.metadata.record_sets if rs.name == record_set):
-            raise ValueError(f"did not find any record set with the name {record_set}.")
+            names = [record_set.name for record_set in self.metadata.record_sets]
+            raise ValueError(
+                f"did not find any record set with the name {record_set}. Possible"
+                f" RecordSets: {names}"
+            )
         return Records(self, record_set, debug=self.debug)
 
 

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download.py
@@ -19,8 +19,10 @@ from mlcroissant._src.core.path import Path
 from mlcroissant._src.core.url import is_url
 from mlcroissant._src.operation_graph.base_operation import Operation
 from mlcroissant._src.structure_graph.nodes.file_object import FileObject
+from mlcroissant._src.structure_graph.nodes.metadata import CroissantVersion
+from mlcroissant._src.structure_graph.nodes.metadata import Metadata
 
-_DOWNLOAD_CHUNK_SIZE = 1024
+_CHUNK_SIZE = 1024
 _GITHUB_GIT = "https://github.com"
 _GITLAB_GIT = "https://gitlab.com"
 _HUGGING_FACE_GIT = "https://huggingface.co/datasets"
@@ -42,10 +44,6 @@ def get_download_filepath(node: FileObject) -> epath.Path:
         return node.mapping[node.name]
     url = node.content_url
     if url and not is_url(url) and not node.contained_in:
-        assert url.startswith("data/"), (
-            f'Local file "{node.uid}" should point to a file within the data/'
-            f' folder next to the JSON-LD Croissant file. But got: "{url}"'
-        )
         if node.folder is None:
             raise ValueError(f"Could not find node folder={node.folder}")
         filepath = node.folder / url
@@ -147,6 +145,31 @@ class Download(Operation):
 
     node: FileObject
 
+    def _check_hash(self, filepath: epath.Path):
+        if filepath.is_dir():
+            return
+        hash = _get_hash_algorithm(self.node)
+        with filepath.open("rb") as f:
+            while chunk := f.read(_CHUNK_SIZE):
+                hash.update(chunk)
+        actual_hash = hash.hexdigest()
+        expected_hash = getattr(self.node, hash.name)
+        if actual_hash != expected_hash:
+            logging.info(
+                "Hash of downloaded file is not identical with"
+                " reference in metadata.json"
+            )
+            # In v0.8 only, hashes were not checked.
+            metadata = self.node.parent
+            if not isinstance(metadata, Metadata):
+                raise ValueError("parent of FileObject should always be Metadata.")
+            if metadata.conforms_to > CroissantVersion.V_0_8:
+                raise ValueError(
+                    f"Hash of downloaded file {filepath} is not identical with the"
+                    f" reference in the Croissant JSON-LD. Expected: {expected_hash} -"
+                    f" Got: {actual_hash}"
+                )
+
     def _download_from_http(self, filepath: epath.Path):
         content_url = self.node.content_url
         assert content_url, "Content URL is None."
@@ -155,9 +178,6 @@ class Download(Operation):
         )
         response.raise_for_status()
         total = int(response.headers.get("Content-Length", 0))
-
-        hash = _get_hash_algorithm(self.node)
-
         with filepath.open("wb") as file, tqdm.tqdm(
             desc=f"Downloading {content_url}...",
             total=total,
@@ -165,23 +185,9 @@ class Download(Operation):
             unit_scale=True,
             unit_divisor=1024,
         ) as bar:
-            for data in response.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE):
+            for data in response.iter_content(chunk_size=_CHUNK_SIZE):
                 size = file.write(data)
-                hash.update(data)
                 bar.update(size)
-
-        downloaded_file_hash = hash.hexdigest()
-
-        if downloaded_file_hash != getattr(self.node, hash.name):
-            logging.info(
-                "Hash of downloaded file is not identical with"
-                " reference in metadata.json"
-            )
-            os.remove(filepath)
-            raise ValueError(
-                "Hash of downloaded file is not identical with"
-                " reference in metadata.json"
-            )
 
     def _download_from_git(self, filepath: epath.Path):
         username = os.environ.get(constants.CROISSANT_GIT_USERNAME)
@@ -209,6 +215,7 @@ class Download(Operation):
                 self._download_from_git(filepath)
             else:
                 self._download_from_http(filepath)
+        self._check_hash(filepath)
         logging.info(
             "File %s is downloaded to %s", self.node.content_url, os.fspath(filepath)
         )

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata.py
@@ -52,6 +52,22 @@ class CroissantVersion(enum.Enum):
             return None
         return self.value
 
+    def __lt__(self, other):
+        """Implements CroissantVersion.V_0_8 < CroissantVersion.V_1_0."""
+        return self.value < other.value
+
+    def __le__(self, other):
+        """Implements CroissantVersion.V_0_8 <= CroissantVersion.V_1_0."""
+        return self.value <= other.value
+
+    def __gt__(self, other):
+        """Implements CroissantVersion.V_1_0 > CroissantVersion.V_0_8."""
+        return self.value > other.value
+
+    def __ge__(self, other):
+        """Implements CroissantVersion.V_1_0 >= CroissantVersion.V_0_8."""
+        return self.value >= other.value
+
 
 @dataclasses.dataclass(eq=False, repr=False)
 class PersonOrOrganization:


### PR DESCRIPTION
At the time when Kaggle/HuggingFace/OpenML implemented their respective APIs, hashes weren't checked so they didn't implement it in 0.8.

This PR makes checking hashes optional in 0.8 and mandatory in 1.0.