### PR TITLE
Fix flaky test

### DIFF
--- a/editor/app.py
+++ b/editor/app.py
@@ -21,7 +21,7 @@ init_state()
 user = get_user()
 
 if OAUTH_CLIENT_ID and not user:
-    query_params = st.experimental_get_query_params()
+    query_params = st.query_params
     state = query_params.get("state")
     if state and state[0] == OAUTH_STATE:
         code = query_params.get("code")
@@ -34,7 +34,7 @@ if OAUTH_CLIENT_ID and not user:
         except:
             raise
         finally:
-            st.experimental_set_query_params()
+            st.query_params = {}
     else:
         redirect_uri = urllib.parse.quote(REDIRECT_URI, safe="")
         client_id = urllib.parse.quote(OAUTH_CLIENT_ID, safe="")
@@ -48,7 +48,7 @@ if OAUTH_CLIENT_ID and not user:
 
 def _back_to_menu():
     """Sends the user back to the menu."""
-    st.experimental_set_query_params()
+    st.query_params = {}
     init_state(force=True)
 
 

--- a/editor/core/query_params.py
+++ b/editor/core/query_params.py
@@ -25,17 +25,17 @@ def _get_query_param(params: dict[str, Any], name: str) -> str | None:
 
 
 def _set_query_param(param: str, new_value: str) -> str | None:
-    params = st.experimental_get_query_params()
+    params = st.query_params
     if params.get(param) == [new_value]:
         # The value already exists in the query params.
         return
     new_params = {k: v for k, v in params.items() if k != param}
     new_params[param] = new_value
-    st.experimental_set_query_params(**new_params)
+    st.query_params = new_params
 
 
 def is_record_set_expanded(record_set: RecordSet) -> bool:
-    params = st.experimental_get_query_params()
+    params = st.query_params
     open_record_set_name = _get_query_param(params, QueryParams.OPEN_RECORD_SET)
     if open_record_set_name:
         return open_record_set_name == record_set.name
@@ -47,7 +47,7 @@ def expand_record_set(record_set: RecordSet) -> None:
 
 
 def get_project_timestamp() -> str | None:
-    params = st.experimental_get_query_params()
+    params = st.query_params
     return _get_query_param(params, QueryParams.OPEN_PROJECT)
 
 

--- a/editor/cypress/e2e/uploadCsv.cy.js
+++ b/editor/cypress/e2e/uploadCsv.cy.js
@@ -59,11 +59,12 @@ describe('Editor loads a local CSV as a resource', () => {
     // I can edit the details of the fields.
     cy.contains('Generating the dataset...').should('not.exist')
     cy.contains('Edit fields details').click()
+    cy.wait(2000)
     cy.get('[data-testid="stExpander"]').last().within(() => {
       cy.get('input[aria-label="Description"]').last().type('This is a nice custom description!{enter}')
     })
-    cy.wait(2000)
-    // TODO(https://github.com/mlcommons/croissant/issues/452): this test is flaky.
-    // cy.get('[data-testid="glide-cell-2-1"]').contains("This is a nice custom description!")
+    cy.get('[data-testid="stExpander"]').last().within(() => {
+      cy.get('input[aria-label="Description"]').last().should('have.value', 'This is a nice custom description!')
+    })
   })
 })


### PR DESCRIPTION
The uploadCsv test was sometimes failing to verify that the Description field was modified.

One of the possible issues was not finding the Description field to type into and check, as it wouldn't be visible in the current view. This was also made more likely due to warnings to migrate usages of  `st.expermental_get_query_params` 
 and `st.expermental_set_query_params` which are now replaced with `st.query_params`.   
In the test itself, now waits after clilcking the "Edit fields" button, so that the necessary input fields appear, instead of waiting after typing and modifies the element lookup.