### PR TITLE
Check live datasets checksums too

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download.py
@@ -169,13 +169,6 @@ class Download(Operation):
         )
 
         ctx = self.node.ctx
-        # For live datasets, we do not raise an error if the hashes checks fail, but
-        # only a warning.
-        if ctx.is_live_dataset:
-            logging.warning(
-                "Hash of downloaded file not identical with reference in metadata.json!"
-            )
-            return
         # In v0.8 only, hashes were not checked.
         if not ctx.is_v0():
             raise ValueError(

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download_test.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download_test.py
@@ -188,7 +188,11 @@ def test_hashes_are_not_checked_for_live_datasets(caplog, dummy_ctx):
         assert "no hash will be checked" in caplog.text
 
 
-def test_hashes_are_checked_for_live_datasets(dummy_ctx):
+@pytest.mark.parametrize(
+    "sha256,md5",
+    [("12345", None), (None, "12345")],
+)
+def test_hashes_are_checked_for_live_datasets(dummy_ctx, sha256, md5):
     with tempfile.NamedTemporaryFile(delete=False) as f:
         filepath = f.name
         metadata = Metadata(ctx=dummy_ctx, name="bar")
@@ -197,7 +201,8 @@ def test_hashes_are_checked_for_live_datasets(dummy_ctx):
             name="foo",
             content_url=os.fspath(filepath),
             # Hash won't match.
-            sha256="12345",
+            sha256=sha256,
+            md5=md5,
         )
         file_object.parents = [metadata]
         download = Download(operations=operations(), node=file_object)

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download_test.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download_test.py
@@ -160,30 +160,6 @@ def test_sha256_hashes_do_match(conforms_to, hash_value):
         download()
 
 
-def test_hashes_are_not_checked_for_live_datasets(caplog):
-    logging.captureWarnings(True)
-    with tempfile.NamedTemporaryFile(delete=False) as f:
-        filepath = f.name
-        ctx = Context(
-            conforms_to=CroissantVersion.V_1_0,
-            folder=epath.Path(),
-            is_live_dataset=True,
-        )
-        metadata = Metadata(ctx=ctx, name="bar")
-        file_object = create_test_file_object(
-            ctx=ctx,
-            name="foo",
-            content_url=os.fspath(filepath),
-            # Hash won't match, but no error raised!
-            sha256="12345",
-        )
-        file_object.parents = [metadata]
-        download = Download(operations=operations(), node=file_object)
-        # Warning is raised, but no error.
-        download()
-        assert "Hash of downloaded file not identical" in caplog.text
-
-
 @pytest.mark.parametrize("conforms_to", CroissantVersion)
 # Test the hex and base64 hash values
 @pytest.mark.parametrize(

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download_test.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download_test.py
@@ -1,7 +1,6 @@
 """download_test module."""
 
 import hashlib
-import logging
 import os
 import tempfile
 


### PR DESCRIPTION
Raise ValueError also for live datasets when hashes of downloaded files do not match