### PR TITLE
Fix query params

### DIFF
--- a/editor/app.py
+++ b/editor/app.py
@@ -22,9 +22,9 @@ user = get_user()
 
 if OAUTH_CLIENT_ID and not user:
     query_params = st.query_params
-    state = query_params.get("state")
+    state = query_params.get_all("state")
     if state and state[0] == OAUTH_STATE:
-        code = query_params.get("code")
+        code = query_params["code"]
         if not code:
             st.stop()
         try:
@@ -34,7 +34,7 @@ if OAUTH_CLIENT_ID and not user:
         except:
             raise
         finally:
-            st.query_params = {}
+            st.query_params.clear()
     else:
         redirect_uri = urllib.parse.quote(REDIRECT_URI, safe="")
         client_id = urllib.parse.quote(OAUTH_CLIENT_ID, safe="")
@@ -48,7 +48,7 @@ if OAUTH_CLIENT_ID and not user:
 
 def _back_to_menu():
     """Sends the user back to the menu."""
-    st.query_params = {}
+    st.query_params.clear()
     init_state(force=True)
 
 

--- a/editor/core/query_params.py
+++ b/editor/core/query_params.py
@@ -15,28 +15,24 @@ class QueryParams:
     OPEN_RECORD_SET = "recordSet"
 
 
-def _get_query_param(params: dict[str, Any], name: str) -> str | None:
+def _get_query_param(name: str) -> str | None:
     """Gets query param with the name `name`."""
-    if name in params:
-        param = params[name]
-        if isinstance(param, list) and len(param) > 0:
-            return param[0]
+    param = st.query_params.get_all(name)
+    if isinstance(param, list) and len(param) > 0:
+        return param[0]
     return None
 
 
 def _set_query_param(param: str, new_value: str) -> str | None:
     params = st.query_params
-    if params.get(param) == [new_value]:
+    if params.get_all(param) == [new_value]:
         # The value already exists in the query params.
         return
-    new_params = {k: v for k, v in params.items() if k != param}
-    new_params[param] = new_value
-    st.query_params = new_params
+    params[param] = new_value
 
 
 def is_record_set_expanded(record_set: RecordSet) -> bool:
-    params = st.query_params
-    open_record_set_name = _get_query_param(params, QueryParams.OPEN_RECORD_SET)
+    open_record_set_name = _get_query_param(QueryParams.OPEN_RECORD_SET)
     if open_record_set_name:
         return open_record_set_name == record_set.name
     return False
@@ -47,8 +43,7 @@ def expand_record_set(record_set: RecordSet) -> None:
 
 
 def get_project_timestamp() -> str | None:
-    params = st.query_params
-    return _get_query_param(params, QueryParams.OPEN_PROJECT)
+    return _get_query_param(QueryParams.OPEN_PROJECT)
 
 
 def set_project(project: CurrentProject):


### PR DESCRIPTION
`query_params` is not a `dict` so usage is a bit different from the return values of `st.experimental_get_query_params`, see [documentation](https://docs.streamlit.io/library/api-reference/utilities/st.query_params)