### PR TITLE
Support both old and new query_params

### DIFF
--- a/editor/app.py
+++ b/editor/app.py
@@ -6,7 +6,9 @@ from components.flex import st_flex
 from core.constants import OAUTH_CLIENT_ID
 from core.constants import OAUTH_STATE
 from core.constants import REDIRECT_URI
+from core.query_params import clear_query_params
 from core.query_params import get_project_timestamp
+from core.query_params import get_state
 from core.state import CurrentProject
 from core.state import get_user
 from core.state import User
@@ -21,8 +23,7 @@ init_state()
 user = get_user()
 
 if OAUTH_CLIENT_ID and not user:
-    query_params = st.query_params
-    state = query_params.get_all("state")
+    state = get_state("state")
     if state and state[0] == OAUTH_STATE:
         code = query_params["code"]
         if not code:
@@ -34,7 +35,7 @@ if OAUTH_CLIENT_ID and not user:
         except:
             raise
         finally:
-            st.query_params.clear()
+            clear_query_params()
     else:
         redirect_uri = urllib.parse.quote(REDIRECT_URI, safe="")
         client_id = urllib.parse.quote(OAUTH_CLIENT_ID, safe="")
@@ -48,7 +49,7 @@ if OAUTH_CLIENT_ID and not user:
 
 def _back_to_menu():
     """Sends the user back to the menu."""
-    st.query_params.clear()
+    clear_query_params()
     init_state(force=True)
 
 

--- a/editor/core/query_params.py
+++ b/editor/core/query_params.py
@@ -15,20 +15,44 @@ class QueryParams:
     OPEN_RECORD_SET = "recordSet"
 
 
+def _has_query_params() -> bool:
+    """Returns whether `query_params` is available, which depends on the streamlit
+    version. If not, st.experimental_get_query_params() and
+    st.experimental_set_query_params() should be used."""
+    return hasattr(st, "query_params")
+
+
 def _get_query_param(name: str) -> str | None:
     """Gets query param with the name `name`."""
-    param = st.query_params.get_all(name)
+    if _has_query_params():
+        param = st.query_params.get_all(name)
+    else:
+        params = st.experimental_get_query_params()
+        if not name in params:
+            return None
+        param = params[name]
+
     if isinstance(param, list) and len(param) > 0:
         return param[0]
     return None
 
 
 def _set_query_param(param: str, new_value: str) -> str | None:
-    params = st.query_params
-    if params.get_all(param) == [new_value]:
-        # The value already exists in the query params.
-        return
-    params[param] = new_value
+    """Sets query param with the name `name` to `new_value`."""
+    if _has_query_params():
+        params = st.query_params
+        if params.get_all(param) == [new_value]:
+            # The value already exists in the query params.
+            return
+        params[param] = new_value
+    else:
+        params = st.experimental_get_query_params()
+        if params.get(param) == [new_value]:
+            # The value already exists in the query params.
+            return
+        new_params = {k: v for k, v in params.items() if k != param}
+        new_params[param] = new_value
+        st.experimental_set_query_params(**new_params)
 
 
 def is_record_set_expanded(record_set: RecordSet) -> bool:
@@ -46,5 +70,17 @@ def get_project_timestamp() -> str | None:
     return _get_query_param(QueryParams.OPEN_PROJECT)
 
 
+def get_state() -> str | None:
+    return _get_query_param("state")
+
+
 def set_project(project: CurrentProject):
     _set_query_param(QueryParams.OPEN_PROJECT, project.path.name)
+
+
+def clear_query_params():
+    """Clears query params."""
+    if _has_query_params():
+        st.query_params.clear()
+    else:
+        st.experimental_set_query_params()


### PR DESCRIPTION
Since Streamlit version 1.30.0., all usages of [`st.experimental_get_query_params()`](https://docs.streamlit.io/library/api-reference/utilities/st.experimental_get_query_params) and [`st.experimental_set_query_params()`](https://docs.streamlit.io/library/api-reference/utilities/st.experimental_set_query_params) should be replaced by [`st.query_params`](https://docs.streamlit.io/library/api-reference/utilities/st.query_params).

However, in older version, using `st.query_params` gives an attribute not found error, therefore modifying the editor to support both the old and the new API.