### PR TITLE
Pass RDF `@id` to nodes as uuid.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           do
             if [ "$notebook" = "recipes/flores200_datapipes.ipynb" ]
             then
+              GITHUB_HEAD_REF="$GITHUB_HEAD_REF"
               MAX_SEQUENCE_LENGTH="10" \
               TRAIN_BATCH_SIZE="1" \
               TEST_BATCH_SIZE="1" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
           do
             if [ "$notebook" = "recipes/flores200_datapipes.ipynb" ]
             then
-              GITHUB_HEAD_REF="$GITHUB_HEAD_REF"
               MAX_SEQUENCE_LENGTH="10" \
               TRAIN_BATCH_SIZE="1" \
               TEST_BATCH_SIZE="1" \

--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -33,6 +33,9 @@ def create_class(mlc_class: type, instance: Any, **kwargs) -> Any:
         name = field.name
         if hasattr(instance, name) and name not in kwargs:
             params[name] = getattr(instance, name)
+    if "uuid" in params and params.get("uuid") is None:
+        # Let mlcroissant handle the default value
+        del params["uuid"]
     return mlc_class(**params, **kwargs)
 
 
@@ -137,6 +140,7 @@ class FileObject:
     sha256: str | None = None
     df: pd.DataFrame | None = None
     folder: epath.PathLike | None = None
+    uuid: str | None = None
 
 
 @dataclasses.dataclass
@@ -149,6 +153,7 @@ class FileSet:
     encoding_format: str | None = ""
     includes: str | None = ""
     name: str = ""
+    uuid: str | None = None
 
 
 @dataclasses.dataclass
@@ -161,6 +166,7 @@ class Field:
     data_types: str | list[str] | None = None
     source: mlc.Source | None = None
     references: mlc.Source | None = None
+    uuid: str | None = None
 
 
 @dataclasses.dataclass
@@ -174,6 +180,7 @@ class RecordSet:
     is_enumeration: bool | None = None
     key: str | list[str] | None = None
     fields: list[Field] = dataclasses.field(default_factory=list)
+    uuid: str | None = None
 
 
 @dataclasses.dataclass
@@ -191,6 +198,7 @@ class Metadata:
     date_published: datetime.datetime | None = None
     license: str | None = ""
     personal_sensitive_information: str | None = None
+    uuid: str | None = None
     url: str = ""
     distribution: list[FileObject | FileSet] = dataclasses.field(default_factory=list)
     record_sets: list[RecordSet] = dataclasses.field(default_factory=list)

--- a/editor/views/overview.py
+++ b/editor/views/overview.py
@@ -10,7 +10,7 @@ from utils import needed_field
 from views.metadata import handle_metadata_change
 from views.metadata import MetadataEvent
 
-_NON_RELEVANT_METADATA = ["ctx", "name", "distribution", "record_sets"]
+_NON_RELEVANT_METADATA = ["ctx", "name", "distribution", "record_sets", "uuid"]
 
 _INFO_TEXT = """Croissant files are composed of three layers:
 
@@ -38,8 +38,9 @@ def _relevant_fields(class_or_instance: type):
     else:
         return [
             field
-            for field, value in dataclasses.asdict(class_or_instance).items()
-            if value and field not in _NON_RELEVANT_METADATA
+            for field in dataclasses.fields(Metadata)
+            if hasattr(class_or_instance, field.name)
+            and field.name not in _NON_RELEVANT_METADATA
         ]
 
 

--- a/python/mlcroissant/mlcroissant/_src/core/uuid.py
+++ b/python/mlcroissant/mlcroissant/_src/core/uuid.py
@@ -6,7 +6,7 @@ from mlcroissant._src.core.types import Json
 
 
 def generate_uid() -> str:
-    """Generates a random UUID of version 4."""
+    """Generates a UUID of version 4 because it's random and simple."""
     return str(uuid.uuid4())
 
 

--- a/python/mlcroissant/mlcroissant/_src/core/uuid.py
+++ b/python/mlcroissant/mlcroissant/_src/core/uuid.py
@@ -1,0 +1,18 @@
+"""Module to manipulate UUID."""
+
+import uuid
+
+from mlcroissant._src.core.types import Json
+
+
+def generate_uid() -> str:
+    """Generates a random UUID of version 4."""
+    return str(uuid.uuid4())
+
+
+def uuid_from_jsonld(jsonld: Json) -> str:
+    """Retrieves uuid from a JSON-LD fragment."""
+    uuid = jsonld.get("@id")
+    if isinstance(uuid, str):
+        return uuid
+    return generate_uid()

--- a/python/mlcroissant/mlcroissant/_src/core/uuid.py
+++ b/python/mlcroissant/mlcroissant/_src/core/uuid.py
@@ -5,7 +5,7 @@ import uuid
 from mlcroissant._src.core.types import Json
 
 
-def generate_uid() -> str:
+def generate_uuid() -> str:
     """Generates a UUID of version 4 because it's random and simple."""
     return str(uuid.uuid4())
 
@@ -15,4 +15,4 @@ def uuid_from_jsonld(jsonld: Json) -> str:
     uuid = jsonld.get("@id")
     if isinstance(uuid, str):
         return uuid
-    return generate_uid()
+    return generate_uuid()

--- a/python/mlcroissant/mlcroissant/_src/datasets.py
+++ b/python/mlcroissant/mlcroissant/_src/datasets.py
@@ -117,6 +117,7 @@ class Records:
         Warning: at the moment, this method yields examples from the first explored
         record_set.
         """
+        # We only consider the operations that are useful to produce the `ReadFields`.
         operations = self._filter_interesting_operations()
         if self.debug:
             graphs_utils.pretty_print_graph(operations)
@@ -125,8 +126,7 @@ class Records:
         # We can stream the dataset iff the operation graph is a path graph (meaning
         # that all operations lie on a single straight line, i.e. have an
         # in-degree of 0 or 1. That means that the operation graph is a single line
-        # (without external joins for example). We only consider the operations that
-        # are useful to produce the `ReadFields(record_set)`.
+        # (without external joins for example).
         can_stream_dataset = all(d == 1 or d == 2 for _, d in operations.degree())
         if can_stream_dataset:
             yield from execute_operations_in_streaming(

--- a/python/mlcroissant/mlcroissant/_src/datasets.py
+++ b/python/mlcroissant/mlcroissant/_src/datasets.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping
 
 from absl import logging
 from etils import epath
+import networkx as nx
 
 from mlcroissant._src.core.context import Context
 from mlcroissant._src.core.graphs import utils as graphs_utils
@@ -15,6 +16,8 @@ from mlcroissant._src.operation_graph import OperationGraph
 from mlcroissant._src.operation_graph.execute import execute_downloads
 from mlcroissant._src.operation_graph.execute import execute_operations_in_streaming
 from mlcroissant._src.operation_graph.execute import execute_operations_sequentially
+from mlcroissant._src.operation_graph.operations import InitOperation
+from mlcroissant._src.operation_graph.operations import ReadFields
 from mlcroissant._src.structure_graph.nodes.metadata import Metadata
 
 
@@ -30,7 +33,7 @@ def get_operations(ctx: Context, metadata: Metadata) -> OperationGraph:
 
 
 def _expand_mapping(
-    mapping: Mapping[str, epath.PathLike] | None
+    mapping: Mapping[str, epath.PathLike] | None,
 ) -> Mapping[str, epath.Path]:
     """Expands the file mapping to pathlib-readable paths."""
     if isinstance(mapping, Mapping):
@@ -114,7 +117,7 @@ class Records:
         Warning: at the moment, this method yields examples from the first explored
         record_set.
         """
-        operations = self.dataset.operations.operations
+        operations = self._filter_interesting_operations()
         if self.debug:
             graphs_utils.pretty_print_graph(operations)
         # Downloads can be parallelized, so we execute them in priority.
@@ -122,7 +125,8 @@ class Records:
         # We can stream the dataset iff the operation graph is a path graph (meaning
         # that all operations lie on a single straight line, i.e. have an
         # in-degree of 0 or 1. That means that the operation graph is a single line
-        # (without external joins for example).
+        # (without external joins for example). We only consider the operations that
+        # are useful to produce the `ReadFields(record_set)`.
         can_stream_dataset = all(d == 1 or d == 2 for _, d in operations.degree())
         if can_stream_dataset:
             yield from execute_operations_in_streaming(
@@ -133,3 +137,21 @@ class Records:
             yield from execute_operations_sequentially(
                 record_set=self.record_set, operations=operations
             )
+
+    def _filter_interesting_operations(self) -> nx.DiGraph:
+        """Filters connected operations to `ReadFields(self.record_set)`."""
+        operations = self.dataset.operations.operations
+        source = next(
+            operation
+            for operation in operations.nodes()
+            if isinstance(operation, InitOperation)
+        )
+        target = next(
+            operation
+            for operation in operations.nodes()
+            if isinstance(operation, ReadFields)
+            and operation.node.name == self.record_set
+        )
+        paths = nx.all_simple_paths(operations, source=source, target=target)
+        interesting_nodes = {node for path in paths for node in path}
+        return operations.subgraph(interesting_nodes)

--- a/python/mlcroissant/mlcroissant/_src/datasets.py
+++ b/python/mlcroissant/mlcroissant/_src/datasets.py
@@ -143,12 +143,12 @@ class Records:
         operations = self.dataset.operations.operations
         source = next(
             operation
-            for operation in operations.nodes()
+            for operation in operations.nodes
             if isinstance(operation, InitOperation)
         )
         target = next(
             operation
-            for operation in operations.nodes()
+            for operation in operations.nodes
             if isinstance(operation, ReadFields)
             and operation.node.name == self.record_set
         )

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import abc
 import dataclasses
-import json
 import re
 from typing import Any
+import uuid
 
 from mlcroissant._src.core import constants
 from mlcroissant._src.core.context import Context
@@ -15,6 +15,11 @@ from mlcroissant._src.core.types import Json
 
 ID_REGEX = "[a-zA-Z0-9\\-_\\.]+"
 _MAX_ID_LENGTH = 255
+
+
+def _generate_uid():
+    """Generates a 16-byte UID."""
+    return str(uuid.uuid4())
 
 
 @dataclasses.dataclass(eq=False, repr=False)
@@ -40,6 +45,9 @@ class Node(abc.ABC):
     ctx: Context = dataclasses.field(default_factory=Context)
     name: str = ""
     parents: list[Node] = dataclasses.field(default_factory=list)
+    # TODO(https://github.com/mlcommons/croissant/discussions/506): During the
+    # implementation of a new reference mechanism, this is deemed to replace `uid`.
+    uuid: str = dataclasses.field(default_factory=_generate_uid)
 
     def __post_init__(self):
         """Checks for `name` (common property between all nodes)."""
@@ -188,36 +196,10 @@ class Node(abc.ABC):
 
     def __hash__(self):
         """Hashes all immutable arguments."""
-        args = []
-        for field in dataclasses.fields(self):
-            # Do not hash unhashable elements:
-            if field.name not in (
-                "ctx",
-                "creators",
-                "data_types",
-                "distribution",
-                "fields",
-                "parents",
-                "record_sets",
-                "sub_fields",
-            ):
-                # If the code failed here, you probably added an unhashable property
-                # that should appear in the allow list above.
-                try:
-                    args.append(_make_hashable(getattr(self, field.name)))
-                except TypeError:
-                    pass
-        return hash(tuple(args))
+        return hash(self.uuid)
 
     def __eq__(self, other: Any) -> bool:
         """Compares two Nodes given their arguments."""
-        if type(self) is not type(other):
-            return False
-        return hash(self) == hash(other)
-
-
-def _make_hashable(arg: Any) -> Any:
-    if isinstance(arg, (dict, list)):
-        return json.dumps(arg)
-    else:
-        return arg
+        if isinstance(other, Node):
+            return self.uuid == other.uuid
+        return False

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
@@ -6,20 +6,15 @@ import abc
 import dataclasses
 import re
 from typing import Any
-import uuid
 
 from mlcroissant._src.core import constants
 from mlcroissant._src.core.context import Context
 from mlcroissant._src.core.issues import Issues
 from mlcroissant._src.core.types import Json
+from mlcroissant._src.core.uuid import generate_uid
 
 ID_REGEX = "[a-zA-Z0-9\\-_\\.]+"
 _MAX_ID_LENGTH = 255
-
-
-def _generate_uid():
-    """Generates a 16-byte UID."""
-    return str(uuid.uuid4())
 
 
 @dataclasses.dataclass(eq=False, repr=False)
@@ -47,7 +42,7 @@ class Node(abc.ABC):
     parents: list[Node] = dataclasses.field(default_factory=list)
     # TODO(https://github.com/mlcommons/croissant/discussions/506): During the
     # implementation of a new reference mechanism, this is deemed to replace `uid`.
-    uuid: str = dataclasses.field(default_factory=_generate_uid)
+    uuid: str = dataclasses.field(default_factory=generate_uid)
 
     def __post_init__(self):
         """Checks for `name` (common property between all nodes)."""

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
@@ -11,7 +11,7 @@ from mlcroissant._src.core import constants
 from mlcroissant._src.core.context import Context
 from mlcroissant._src.core.issues import Issues
 from mlcroissant._src.core.types import Json
-from mlcroissant._src.core.uuid import generate_uid
+from mlcroissant._src.core.uuid import generate_uuid
 
 ID_REGEX = "[a-zA-Z0-9\\-_\\.]+"
 _MAX_ID_LENGTH = 255
@@ -42,7 +42,7 @@ class Node(abc.ABC):
     parents: list[Node] = dataclasses.field(default_factory=list)
     # TODO(https://github.com/mlcommons/croissant/discussions/506): During the
     # implementation of a new reference mechanism, this is deemed to replace `uid`.
-    uuid: str = dataclasses.field(default_factory=generate_uid)
+    uuid: str = dataclasses.field(default_factory=generate_uuid)
 
     def __post_init__(self):
         """Checks for `name` (common property between all nodes)."""
@@ -56,14 +56,20 @@ class Node(abc.ABC):
                 If the node doesn't have one, it triggers an error.
         """
         for mandatory_property in mandatory_properties:
-            value = getattr(self, mandatory_property)
-            if not value:
-                error = (
-                    "Property"
-                    f' "{constants.FROM_CROISSANT(self.ctx).get(mandatory_property)}"'
-                    " is mandatory, but does not exist."
+            if hasattr(self, mandatory_property):
+                value = getattr(self, mandatory_property)
+                if not value:
+                    error = (
+                        "Property"
+                        f' "{constants.FROM_CROISSANT(self.ctx).get(mandatory_property)}"'
+                        " is mandatory, but does not exist."
+                    )
+                    self.add_error(error)
+            else:
+                self.add_error(
+                    "mlcroissant checks for an inexisting property:"
+                    f" {mandatory_property}"
                 )
-                self.add_error(error)
 
     def assert_has_optional_properties(self, *optional_properties: str):
         """Checks a node in the graph for existing properties with constraints.
@@ -73,14 +79,20 @@ class Node(abc.ABC):
                 the node doesn't have one, it triggers a warning.
         """
         for optional_property in optional_properties:
-            value = getattr(self, optional_property)
-            if not value:
-                error = (
-                    "Property"
-                    f' "{constants.FROM_CROISSANT(self.ctx).get(optional_property)}" is'
-                    " recommended, but does not exist."
+            if hasattr(self, optional_property):
+                value = getattr(self, optional_property)
+                if not value:
+                    error = (
+                        "Property"
+                        f' "{constants.FROM_CROISSANT(self.ctx).get(optional_property)}"'
+                        " is recommended, but does not exist."
+                    )
+                    self.add_warning(error)
+            else:
+                self.add_error(
+                    "mlcroissant checks for an inexisting property:"
+                    f" {optional_property}"
                 )
-                self.add_warning(error)
 
     def assert_has_exclusive_properties(self, *exclusive_properties: list[str]):
         """Checks a node in the graph for existing properties with constraints.
@@ -198,3 +210,20 @@ class Node(abc.ABC):
         if isinstance(other, Node):
             return self.uuid == other.uuid
         return False
+
+    def __deepcopy__(self, memo):
+        """Overwrites [`copy.deepcopy`](https://docs.python.org/3/library/copy.html).
+
+        This is required to use `copy.deepcopy(metadata)` as needed by e.g. PyTorch
+        DataPipes. It is unsure what the full consequences are. So we'll keep
+        investigating on a better approach in
+        https://github.com/mlcommons/croissant/issues/531.
+        """
+        kwargs = {}
+        for field in dataclasses.fields(self.__class__):
+            if field.name in self.__dict__:
+                kwargs[field.name] = self.__dict__[field.name]
+        # We properly selected the correct kwargs:
+        copy = self.__class__(**kwargs)  # pytype: disable=not-instantiable
+        memo[id(self)] = copy
+        return copy

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/base_node_test.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/base_node_test.py
@@ -68,15 +68,10 @@ def test_validate_name(name, expected_errors):
 
 
 def test_eq():
-    node_1_with_parent_a = create_test_node(Node, name="node1")
-    node_1_with_parent_a.parents = ["parentA"]
-    node_1_with_parent_b = create_test_node(Node, name="node1")
-    node_1_with_parent_b.parents = ["parentB"]
-    node_2_with_parent_a = create_test_node(Node, name="node2")
-    node_2_with_parent_a.parents = ["parentA"]
-    node_2_with_parent_b = create_test_node(Node, name="node2")
-    node_2_with_parent_b.parents = ["parentB"]
-    assert node_1_with_parent_a == node_1_with_parent_b
-    assert node_2_with_parent_a == node_2_with_parent_b
-    assert node_1_with_parent_a != node_2_with_parent_a
-    assert node_1_with_parent_a != node_2_with_parent_b
+    node1 = create_test_node(Node, uuid="node1", name="node1")
+    node2 = create_test_node(Node, uuid="node2", name="node2")
+    node1_doppelganger = create_test_node(Node, uuid="node1", name="node1_doppelganger")
+    # Same UUID.
+    assert node1 == node1_doppelganger
+    # Different UUID.
+    assert node1 != node2

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/graph.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/graph.py
@@ -54,7 +54,6 @@ def from_nodes_to_graph(metadata) -> nx.MultiDiGraph:
     graph = nx.MultiDiGraph()
     # Bind graph to nodes:
     for node in metadata.nodes():
-        node.ctx.graph = graph
         graph.add_node(node)
     uid_to_node = _check_no_duplicate(metadata)
     for node in metadata.distribution:

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/field.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/field.py
@@ -13,6 +13,7 @@ from mlcroissant._src.core.data_types import check_expected_type
 from mlcroissant._src.core.data_types import EXPECTED_DATA_TYPES
 from mlcroissant._src.core.json_ld import remove_empty_values
 from mlcroissant._src.core.types import Json
+from mlcroissant._src.core.uuid import uuid_from_jsonld
 from mlcroissant._src.structure_graph.base_node import Node
 from mlcroissant._src.structure_graph.nodes.source import Source
 
@@ -180,5 +181,5 @@ class Field(Node):
             repeated=repeated,
             source=source,
             sub_fields=sub_fields,
-            uuid=field.get("@id"),
+            uuid=uuid_from_jsonld(field),
         )

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/field.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/field.py
@@ -180,4 +180,5 @@ class Field(Node):
             repeated=repeated,
             source=source,
             sub_fields=sub_fields,
+            uuid=field.get("@id"),
         )

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object.py
@@ -84,4 +84,5 @@ class FileObject(Node):
             name=name,
             sha256=file_object.get(constants.SCHEMA_ORG_SHA256),
             source=file_object.get(constants.ML_COMMONS_SOURCE(ctx)),
+            uuid=file_object.get("@id"),
         )

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object.py
@@ -9,6 +9,7 @@ from mlcroissant._src.core.context import Context
 from mlcroissant._src.core.data_types import check_expected_type
 from mlcroissant._src.core.json_ld import remove_empty_values
 from mlcroissant._src.core.types import Json
+from mlcroissant._src.core.uuid import uuid_from_jsonld
 from mlcroissant._src.structure_graph.base_node import Node
 from mlcroissant._src.structure_graph.nodes.source import Source
 
@@ -84,5 +85,5 @@ class FileObject(Node):
             name=name,
             sha256=file_object.get(constants.SCHEMA_ORG_SHA256),
             source=file_object.get(constants.ML_COMMONS_SOURCE(ctx)),
-            uuid=file_object.get("@id"),
+            uuid=uuid_from_jsonld(file_object),
         )

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object_test.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object_test.py
@@ -70,12 +70,12 @@ def test_from_jsonld(encoding):
     }
     ctx.mapping = {"file1": epath.Path("~/Downloads/file1.csv")}
     file_object = FileObject.from_jsonld(ctx, jsonld)
-    assert file_object == FileObject(
-        ctx=ctx,
-        name="foo",
-        description="bar",
-        content_url="https://mlcommons.org",
-        encoding_format=encoding,
-        sha256="48a7c257f3c90b2a3e529ddd2cca8f4f1bd8e49ed244ef53927649504ac55354",
+    assert file_object.name == "foo"
+    assert file_object.description == "bar"
+    assert file_object.content_url == "https://mlcommons.org"
+    assert file_object.encoding_format == encoding
+    assert (
+        file_object.sha256
+        == "48a7c257f3c90b2a3e529ddd2cca8f4f1bd8e49ed244ef53927649504ac55354"
     )
     assert not ctx.issues.errors

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_set.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_set.py
@@ -9,6 +9,7 @@ from mlcroissant._src.core.context import Context
 from mlcroissant._src.core.data_types import check_expected_type
 from mlcroissant._src.core.json_ld import remove_empty_values
 from mlcroissant._src.core.types import Json
+from mlcroissant._src.core.uuid import uuid_from_jsonld
 from mlcroissant._src.structure_graph.base_node import Node
 
 
@@ -61,5 +62,5 @@ class FileSet(Node):
             encoding_format=file_set.get(constants.SCHEMA_ORG_ENCODING_FORMAT),
             includes=file_set.get(constants.ML_COMMONS_INCLUDES(ctx)),
             name=name,
-            uuid=file_set.get("@id"),
+            uuid=uuid_from_jsonld(file_set),
         )

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_set.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_set.py
@@ -61,4 +61,5 @@ class FileSet(Node):
             encoding_format=file_set.get(constants.SCHEMA_ORG_ENCODING_FORMAT),
             includes=file_set.get(constants.ML_COMMONS_INCLUDES(ctx)),
             name=name,
+            uuid=file_set.get("@id"),
         )

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_set_test.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_set_test.py
@@ -35,12 +35,10 @@ def test_from_jsonld(conforms_to):
         constants.SCHEMA_ORG_ENCODING_FORMAT: "application/json",
         constants.ML_COMMONS_INCLUDES(ctx): "*.json",
     }
-    assert FileSet.from_jsonld(ctx, jsonld) == FileSet(
-        ctx=ctx,
-        name="foo",
-        description="bar",
-        contained_in=["some.zip"],
-        encoding_format="application/json",
-        includes="*.json",
-    )
+    file_set = FileSet.from_jsonld(ctx, jsonld)
+    file_set.name == "foo"
+    file_set.description == "bar"
+    file_set.contained_in == ["some.zip"]
+    file_set.encoding_format == "application/json"
+    file_set.includes == "*.json"
     assert not ctx.issues.errors

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata.py
@@ -21,6 +21,7 @@ from mlcroissant._src.core.json_ld import remove_empty_values
 from mlcroissant._src.core.rdf import Rdf
 from mlcroissant._src.core.types import Json
 from mlcroissant._src.core.url import is_url
+from mlcroissant._src.core.uuid import uuid_from_jsonld
 from mlcroissant._src.structure_graph.base_node import Node
 from mlcroissant._src.structure_graph.graph import from_file_to_json
 from mlcroissant._src.structure_graph.graph import from_nodes_to_graph
@@ -309,7 +310,7 @@ class Metadata(Node):
                 constants.ML_COMMONS_PERSONAL_SENSITVE_INFORMATION(ctx)
             ),
             record_sets=record_sets,
-            uuid=metadata.get("@id"),
+            uuid=uuid_from_jsonld(metadata),
             url=url,
             version=metadata.get(constants.SCHEMA_ORG_VERSION),
         )

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata.py
@@ -309,6 +309,7 @@ class Metadata(Node):
                 constants.ML_COMMONS_PERSONAL_SENSITVE_INFORMATION(ctx)
             ),
             record_sets=record_sets,
+            uuid=metadata.get("@id"),
             url=url,
             version=metadata.get(constants.SCHEMA_ORG_VERSION),
         )

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata_test.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata_test.py
@@ -47,18 +47,16 @@ def test_from_jsonld(conforms_to: CroissantVersion):
             ctx
         ): "personal_sensitive_information",
     }
-    assert Metadata.from_jsonld(ctx, jsonld) == Metadata(
-        ctx=ctx,
-        name="foo",
-        description="bar",
-        data_biases="data_biases",
-        data_collection="data_collection",
-        license="License",
-        is_live_dataset=False,
-        personal_sensitive_information="personal_sensitive_information",
-        url="https://mlcommons.org",
-        version="1.0.0",
-    )
+    metadata = Metadata.from_jsonld(ctx, jsonld)
+    metadata.name == "foo"
+    metadata.description == "bar"
+    metadata.data_biases == "data_biases"
+    metadata.data_collection == "data_collection"
+    metadata.license == "License"
+    metadata.is_live_dataset == False
+    metadata.personal_sensitive_information == "personal_sensitive_information"
+    metadata.url == "https://mlcommons.org"
+    metadata.version == "1.0.0"
     assert not ctx.issues.errors
 
 

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata_test.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata_test.py
@@ -1,5 +1,6 @@
 """Tests for Metadata."""
 
+import copy
 from unittest import mock
 
 import pytest
@@ -105,3 +106,11 @@ def test_issues_in_metadata_are_shared_with_children():
             # We did not specify the RecordSet's name. Hence the exception above:
             record_sets=[RecordSet(description="description")],
         )
+
+
+def test_metadata_can_be_deep_copied():
+    metadata = Metadata(name="foo")
+    # PyTorch DataPipes requries copy.deepcopy:
+    copied_metadata = copy.deepcopy(metadata)
+    assert copied_metadata.name == metadata.name == "foo"
+    assert copied_metadata is not metadata

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set.py
@@ -107,6 +107,7 @@ class RecordSet(Node):
             key=key,
             fields=fields,
             name=record_set_name,
+            uuid=record_set.get("@id"),
         )
 
     def check_joins_in_fields(self, fields: list[Field]):

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set.py
@@ -11,6 +11,7 @@ from mlcroissant._src.core.context import Context
 from mlcroissant._src.core.data_types import check_expected_type
 from mlcroissant._src.core.json_ld import remove_empty_values
 from mlcroissant._src.core.types import Json
+from mlcroissant._src.core.uuid import uuid_from_jsonld
 from mlcroissant._src.structure_graph.base_node import Node
 from mlcroissant._src.structure_graph.nodes.field import Field
 from mlcroissant._src.structure_graph.nodes.source import get_parent_uid
@@ -107,7 +108,7 @@ class RecordSet(Node):
             key=key,
             fields=fields,
             name=record_set_name,
-            uuid=record_set.get("@id"),
+            uuid=uuid_from_jsonld(record_set),
         )
 
     def check_joins_in_fields(self, fields: list[Field]):

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set_test.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set_test.py
@@ -84,14 +84,12 @@ def test_from_jsonld(conforms_to: CroissantVersion):
         constants.SCHEMA_ORG_KEY(ctx): ["key1", "key2"],
         constants.ML_COMMONS_DATA(ctx): [{"column1": ["value1", "value2"]}],
     }
-    assert RecordSet.from_jsonld(ctx, jsonld) == RecordSet(
-        ctx=ctx,
-        name="foo",
-        description="bar",
-        is_enumeration=True,
-        key=["key1", "key2"],
-        data=[{"column1": ["value1", "value2"]}],
-    )
+    record_set = RecordSet.from_jsonld(ctx, jsonld)
+    record_set.name == "foo"
+    record_set.description == "bar"
+    record_set.is_enumeration == True
+    record_set.key == ["key1", "key2"]
+    record_set.data == [{"column1": ["value1", "value2"]}]
     assert ctx.issues.errors == {
         (
             "[RecordSet(foo)] Line #0 doesn't have the expected columns. Expected:"


### PR DESCRIPTION
- Start deprecating `uid` to be replaced by `uuid`.
- Better hashing (as a consequence I discovered some issues in some datasets).