### PR TITLE
716 more Hugging Face datasets can be read by mlcroissant.

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/core/context.py
+++ b/python/mlcroissant/mlcroissant/_src/core/context.py
@@ -87,3 +87,10 @@ class Context:
     def is_v0(self):
         """Whether the JSON-LD conforms to Croissant v0.8 or lower."""
         return self.conforms_to < CroissantVersion.V_1_0
+
+    def node_by_uid(self, uid: str | None):
+        """Retrieves a node in the graph by its UID."""
+        for node in self.graph.nodes():
+            if node.uid == uid:
+                return node
+        return None

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/base_operation.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/base_operation.py
@@ -12,9 +12,10 @@ from mlcroissant._src.structure_graph.base_node import Node
 
 
 class Operations(nx.DiGraph):
-    """Overwrites nx.DiGraph to keep track of last operations.
+    """Overwrites nx.DiGraph to keep track of operations.
 
-    `self.last_operations` maintains a pointer to the last operation for each node.
+    `self.last_operations` maintains a pointer to the chain of last operations for each
+    node.
     """
 
     def __init__(self):

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/graph.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/graph.py
@@ -43,13 +43,7 @@ def _add_operations_for_record_set(
     operations: Operations,
     record_set: RecordSet,
 ):
-    """Adds all operations for a node of type `RecordSet`.
-
-    Operations are:
-
-    - `Join` if the field comes from several sources.
-    - `ReadFields` to specify how the fields are read.
-    """
+    """Adds all operations for a node of type `RecordSet`."""
     if record_set.data:
         Data(operations=operations, node=record_set)
         return

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
@@ -152,6 +152,22 @@ class Node(abc.ABC):
         return set(self.ctx.graph.predecessors(self))
 
     @property
+    def recursive_predecessors(self) -> set[Node]:
+        """Predecessors and predecessors of predecessors in the structure graph."""
+        predecessors = set()
+        for predecessor in self.predecessors:
+            predecessors.add(predecessor)
+            predecessors.update(predecessor.recursive_predecessors)
+        return predecessors
+
+    @property
+    def predecessor(self) -> Node | None:
+        """First predecessor in the structure graph."""
+        if not self.ctx.graph.has_node(self):
+            return None
+        return next(self.ctx.graph.predecessors(self), None)
+
+    @property
     def successors(self) -> tuple[Node, ...]:
         """Successors in the structure graph."""
         if self not in self.ctx.graph:
@@ -159,6 +175,22 @@ class Node(abc.ABC):
         # We use tuples in order to have a hashable data structure to be put in input of
         # operations.
         return tuple(self.ctx.graph.successors(self))
+
+    @property
+    def recursive_successors(self) -> set[Node]:
+        """Successors and successors of successors in the structure graph."""
+        successors = set()
+        for successor in self.successors:
+            successors.add(successor)
+            successors.update(successor.recursive_successors)
+        return successors
+
+    @property
+    def successor(self) -> Node | None:
+        """Direct successor in the structure graph."""
+        if not self.ctx.graph.has_node(self):
+            return None
+        return next(self.ctx.graph.successors(self), None)
 
     @property
     def issues(self) -> Issues:

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/graph.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/graph.py
@@ -26,9 +26,9 @@ import networkx as nx
 from mlcroissant._src.core import constants
 from mlcroissant._src.core.types import Json
 from mlcroissant._src.structure_graph.base_node import Node
-from mlcroissant._src.structure_graph.nodes.field import Field
 from mlcroissant._src.structure_graph.nodes.file_object import FileObject
 from mlcroissant._src.structure_graph.nodes.file_set import FileSet
+from mlcroissant._src.structure_graph.nodes.record_set import RecordSet
 
 
 def from_file_to_json(filepath: epath.PathLike) -> tuple[epath.Path, Json]:
@@ -62,15 +62,14 @@ def from_nodes_to_graph(metadata) -> nx.MultiDiGraph:
                 _add_edge(graph, uid_to_node, uid, node)
     for record_set in metadata.record_sets:
         for field in record_set.fields:
-            if record_set.data:
-                _add_edge(graph, uid_to_node, record_set.uid, field)
+            _add_edge(graph, uid_to_node, record_set.uid, field)
             for origin in [field.source, field.references]:
                 if origin:
-                    _add_edge(graph, uid_to_node, origin.uid, field)
+                    _add_edge(graph, uid_to_node, origin.uid, record_set)
             for sub_field in field.sub_fields:
                 for origin in [sub_field.source, sub_field.references]:
                     if origin:
-                        _add_edge(graph, uid_to_node, origin.uid, sub_field)
+                        _add_edge(graph, uid_to_node, origin.uid, record_set)
     # `Metadata` are used as the entry node.
     _add_node_as_entry_node(graph, metadata)
     return graph
@@ -86,22 +85,24 @@ def _get_entry_nodes(graph: nx.MultiDiGraph, node: Node) -> list[Node]:
     # Fields should usually not be entry nodes, except if they have subFields. So we
     # check for this:
     for node in entry_nodes:
-        if isinstance(node, Field) and not node.sub_fields and not node.data:
-            if not node.source:
-                node.add_error(
-                    f'Node "{node.uid}" is a field and has no source. Please, use'
-                    f" {constants.ML_COMMONS_SOURCE(ctx)} to specify the source."
-                )
-            else:
-                uid = node.source.uid
-                node.add_error(
-                    f"Malformed source data: {uid}. It does not refer to any existing"
-                    f" node. Have you used {constants.ML_COMMONS_FIELD(ctx)} or"
-                    f" {constants.SCHEMA_ORG_DISTRIBUTION} to indicate the source field"
-                    " or the source distribution? If you specified a field, it should"
-                    " contain all the names from the RecordSet separated by `/`, e.g.:"
-                    ' "record_set_name/field_name"'
-                )
+        if isinstance(node, RecordSet) and not node.data:
+            for field in node.fields:
+                if not field.source:
+                    field.add_error(
+                        f'Node "{field.uid}" is a field and has no source. Please, use'
+                        f" {constants.ML_COMMONS_SOURCE(ctx)} to specify the source."
+                    )
+                else:
+                    uid = field.source.uid
+                    field.add_error(
+                        f"Malformed source data: {uid}. It does not refer to any"
+                        " existing node. Have you used"
+                        f" {constants.ML_COMMONS_FIELD(ctx)} or"
+                        f" {constants.SCHEMA_ORG_DISTRIBUTION} to indicate the source"
+                        " field or the source distribution? If you specified a field,"
+                        " it should contain all the names from the RecordSet separated"
+                        ' by `/`, e.g.: "record_set_name/field_name"'
+                    )
     return entry_nodes
 
 

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/field.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/field.py
@@ -103,16 +103,16 @@ class Field(Node):
                     DataType.AUDIO_OBJECT,
                 ]:
                     return term.URIRef(data_type)
-        # The data_type has to be found on a predecessor:
-        predecessor = next((p for p in self.predecessors if isinstance(p, Field)), None)
-        if predecessor is None:
+        # The data_type has to be found on the source:
+        source = self.ctx.node_by_uid(self.source.uid)
+        if not isinstance(source, Field):
             self.add_error(
                 "The field does not specify a valid"
-                f" {constants.ML_COMMONS_DATA_TYPE(self.ctx)}, neither does any of its"
-                f" predecessor. Got: {self.data_types}"
+                f" {constants.ML_COMMONS_DATA_TYPE(self.ctx)}, neither does any of"
+                f" its predecessor. Got: {self.data_types}"
             )
             return None
-        return predecessor.data_type
+        return source.data_type
 
     @property
     def data(self) -> str | None:

--- a/python/mlcroissant/mlcroissant/_src/tests/graphs/0.8/mlfield_bad_source/output.txt
+++ b/python/mlcroissant/mlcroissant/_src/tests/graphs/0.8/mlfield_bad_source/output.txt
@@ -1,5 +1,5 @@
 Found the following 2 error(s) during the validation:
   -  [Metadata(mydataset) > RecordSet(a-record-set) > Field(first-field)] Malformed source data: THISDOESNOTEXIST. It does not refer to any existing node. Have you used http://mlcommons.org/schema/field or https://schema.org/distribution to indicate the source field or the source distribution? If you specified a field, it should contain all the names from the RecordSet separated by `/`, e.g.: "record_set_name/field_name"
-  -  [Metadata(mydataset) > RecordSet(a-record-set) > Field(first-field)] There is a reference to node named "THISDOESNOTEXIST" in node "a-record-set/first-field", but this node doesn't exist.
+  -  [Metadata(mydataset) > RecordSet(a-record-set)] There is a reference to node named "THISDOESNOTEXIST" in node "a-record-set", but this node doesn't exist.
 Found the following 1 warning(s) during the validation:
   -  [Metadata(mydataset) > RecordSet(a-record-set) > Field(first-field)] Property "https://schema.org/description" is recommended, but does not exist.

--- a/python/mlcroissant/mlcroissant/_src/tests/graphs/1.0/mlfield_bad_source/output.txt
+++ b/python/mlcroissant/mlcroissant/_src/tests/graphs/1.0/mlfield_bad_source/output.txt
@@ -1,5 +1,5 @@
 Found the following 2 error(s) during the validation:
   -  [Metadata(mydataset) > RecordSet(a-record-set) > Field(first-field)] Malformed source data: THISDOESNOTEXIST. It does not refer to any existing node. Have you used http://mlcommons.org/croissant/field or https://schema.org/distribution to indicate the source field or the source distribution? If you specified a field, it should contain all the names from the RecordSet separated by `/`, e.g.: "record_set_name/field_name"
-  -  [Metadata(mydataset) > RecordSet(a-record-set) > Field(first-field)] There is a reference to node named "THISDOESNOTEXIST" in node "a-record-set/first-field", but this node doesn't exist.
+  -  [Metadata(mydataset) > RecordSet(a-record-set)] There is a reference to node named "THISDOESNOTEXIST" in node "a-record-set", but this node doesn't exist.
 Found the following 1 warning(s) during the validation:
   -  [Metadata(mydataset) > RecordSet(a-record-set) > Field(first-field)] Property "https://schema.org/description" is recommended, but does not exist.

--- a/python/mlcroissant/mlcroissant/_src/tests/operations.py
+++ b/python/mlcroissant/mlcroissant/_src/tests/operations.py
@@ -1,8 +1,8 @@
 """Testing utils for `Operation`."""
 
-import networkx as nx
+from mlcroissant._src.operation_graph.base_operation import Operations
 
 
-def operations() -> nx.DiGraph:
+def operations() -> Operations:
     """An empty graph of operations to be used in tests."""
-    return nx.DiGraph()
+    return Operations()


### PR DESCRIPTION
- **Readability improvement**: we remove the function `last_operations`.

- **Correctness**: the operation graph has less bugs (see u.a. "huggingface-c4" or "coco204-mini"):
<img width="1160" alt="image" src="https://github.com/mlcommons/croissant/assets/17081356/5ef1ec77-ee02-47df-ada6-95bde116d2c2">

- **Performance improvement**: we remove a Dijkstra+for-loop (`O(n^2)`) in profit of a hashmap storing the last operations (`O(1)`).

Example of dataset that used to timeout and is now usable:

```python
import mlcroissant as mlc
mlc.Dataset("https://datasets-server.huggingface.co/croissant?dataset=gcaillaut/citeseer")
```

More than 700 Hugging Face datasets were similarly impacted (see the [announcement](https://groups.google.com/a/mlcommons.org/g/croissant/c/EpbC0wkuF6g)).

Fixes: https://github.com/mlcommons/croissant/issues/310 and https://github.com/mlcommons/croissant/issues/525.