### PR TITLE
Allow to load RecordSets with inline data only.

### DIFF
--- a/datasets/0.8/coco2014-mini/output/split_enums.jsonl
+++ b/datasets/0.8/coco2014-mini/output/split_enums.jsonl
@@ -1,0 +1,3 @@
+{"name": "train", "url": "https://mlcommons.org/definitions/training_split"}
+{"name": "val", "url": "https://mlcommons.org/definitions/validation_split"}
+{"name": "test", "url": "https://mlcommons.org/definitions/test_split"}

--- a/datasets/1.0/coco2014-mini/output/split_enums.jsonl
+++ b/datasets/1.0/coco2014-mini/output/split_enums.jsonl
@@ -1,0 +1,3 @@
+{"name": "train", "url": "https://mlcommons.org/definitions/training_split"}
+{"name": "val", "url": "https://mlcommons.org/definitions/validation_split"}
+{"name": "test", "url": "https://mlcommons.org/definitions/test_split"}

--- a/python/mlcroissant/mlcroissant/_src/datasets_test.py
+++ b/python/mlcroissant/mlcroissant/_src/datasets_test.py
@@ -101,6 +101,7 @@ def load_records_and_test_equality(
         ["coco2014-mini/metadata.json", "bounding_boxes", -1],
         ["coco2014-mini/metadata.json", "captions", -1],
         ["coco2014-mini/metadata.json", "images", -1],
+        ["coco2014-mini/metadata.json", "split_enums", -1],
         ["pass-mini/metadata.json", "images", -1],
         ["recipes/file_object_in_zip.json", "csv1", -1],
         ["recipes/file_object_in_zip.json", "csv2", -1],

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/base_operation.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/base_operation.py
@@ -73,10 +73,14 @@ class Operation(abc.ABC):
         """Adds the operation to the graph of operations."""
         self.operations.add_node(self)
         self.connect_to_last_operation(self.node)
-        self.operations.last_operations[self.node] = self
-        if self.node.successor:
+        self.set_last_operation_for(self.node)
+
+    def set_last_operation_for(self, node: Node):
+        """Sets self as the last operation for the node and its successors."""
+        self.operations.last_operations[node] = self
+        for successor in node.successors:
             # Report the last operation to the next node in the graph.
-            self.operations.last_operations[self.node.successor] = self
+            self.operations.last_operations[successor] = self
 
     def connect_to_last_operation(self, node: Node):
         """Connects the current operation (self) to the last operation for node."""

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/graph.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/graph.py
@@ -45,8 +45,9 @@ def _add_operations_for_record_set(
 ):
     """Adds all operations for a node of type `RecordSet`."""
     if record_set.data:
-        Data(operations=operations, node=record_set)
-        return
+        Data(operations=operations, node=record_set) >> ReadFields(
+            operations=operations, node=record_set
+        )
     has_join = any(field for field in record_set.fields if field.references.uid)
     if has_join:
         Join(operations=operations, node=record_set) >> ReadFields(

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field.py
@@ -155,6 +155,11 @@ class ReadFields(Operation):
 
     def __call__(self, df: pd.DataFrame) -> Iterator[dict[str, Any]]:
         """See class' docstring."""
+        if self.node.data:
+            # The RecordSet has `data`, so we directly yield from the dataframe.
+            for _, row in df.iterrows():
+                yield dict(row)
+            return
         fields = self._fields()
         for field in fields:
             df = _extract_value(df, field)


### PR DESCRIPTION
Fixes https://github.com/mlcommons/croissant/issues/501.

Full operation graph:

<img width="1290" alt="image" src="https://github.com/mlcommons/croissant/assets/17081356/69596061-e69f-44b6-a356-05a30058fb38">

Operation graph for the RecordSet:

<img width="329" alt="image" src="https://github.com/mlcommons/croissant/assets/17081356/6a3aae80-17ff-42a4-85f0-9c7a95adef72">