### PR TITLE
Add TSV to editor

### DIFF
--- a/editor/core/files.py
+++ b/editor/core/files.py
@@ -54,7 +54,7 @@ class FileTypes:
     )
     TXT = FileType(
         name="Text",
-        encoding_format="plain/text",
+        encoding_format="text/plain",
         extensions=["txt"],
     )
     ZIP = FileType(

--- a/editor/core/files_test.py
+++ b/editor/core/files_test.py
@@ -10,12 +10,13 @@ FileTypes = files_module.FileTypes
 
 
 @mock.patch.object(files_module, "guess_file_type", return_value=FileTypes.CSV)
-def test_check_file_csv(guess_file_type):
+def test_check_file_csv_url(guess_file_type):
     del guess_file_type
     csv = epath.Path(
         # This is the hash path for "https://my.url".
         "/tmp/croissant-editor-f76b4732c82d83daf858fae2cc0e590d352a4bceb781351243a03daab11f76bc"
     )
+    # Test typical CSV
     if csv.exists():
         csv.unlink()
     with csv.open("w") as f:
@@ -27,6 +28,51 @@ def test_check_file_csv(guess_file_type):
     pd.testing.assert_frame_equal(
         file.df, pd.DataFrame({"column1": ["a", "b", "c"], "column2": [1, 2, 3]})
     )
+
+    # Test error thrown on no file
+    csv.unlink()
+    with pytest.raises(Exception):
+        files_module.file_from_url("https://my.url", set(), epath.Path())
+
+    # Test escaped CSV
+    content = b'"This","Is"\n1,2\n3,4'
+    with csv.open("wb") as f:
+        f.write(content)
+    file = files_module.file_from_url("https://my.url", set(), epath.Path())
+    pd.testing.assert_frame_equal(file.df, pd.DataFrame({"This": [1, 3], "Is": [2, 4]}))
+
+
+@mock.patch.object(files_module, "guess_file_type", return_value=FileTypes.TSV)
+def test_check_file_tsv_url(guess_file_type):
+    del guess_file_type
+    tsv = epath.Path(
+        # This is the hash path for "https://my.url".
+        "/tmp/croissant-editor-f76b4732c82d83daf858fae2cc0e590d352a4bceb781351243a03daab11f76bc"
+    )
+    # Test typical CSV
+    if tsv.exists():
+        tsv.unlink()
+    with tsv.open("w") as f:
+        f.write("column1\tcolumn2\n")
+        f.write("a\t1\n")
+        f.write("b\t2\n")
+        f.write("c\t3\n")
+    file = files_module.file_from_url("https://my.url", set(), epath.Path())
+    pd.testing.assert_frame_equal(
+        file.df, pd.DataFrame({"column1": ["a", "b", "c"], "column2": [1, 2, 3]})
+    )
+
+    # Test error thrown on no file
+    tsv.unlink()
+    with pytest.raises(Exception):
+        files_module.file_from_url("https://my.url", set(), epath.Path())
+
+    # Test escaped TSV
+    content = b'"This"\t"Is"\n1\t2\n3\t4'
+    with tsv.open("wb") as f:
+        f.write(content)
+    file = files_module.file_from_url("https://my.url", set(), epath.Path())
+    pd.testing.assert_frame_equal(file.df, pd.DataFrame({"This": [1, 3], "Is": [2, 4]}))
 
 
 @mock.patch.object(files_module, "guess_file_type", return_value="unknown")

--- a/editor/core/files_test.py
+++ b/editor/core/files_test.py
@@ -16,7 +16,7 @@ def test_check_file_csv_url(guess_file_type):
         # This is the hash path for "https://my.url".
         "/tmp/croissant-editor-f76b4732c82d83daf858fae2cc0e590d352a4bceb781351243a03daab11f76bc"
     )
-    # Test typical CSV
+    # Test unescaped CSV
     if csv.exists():
         csv.unlink()
     with csv.open("w") as f:
@@ -49,7 +49,7 @@ def test_check_file_tsv_url(guess_file_type):
         # This is the hash path for "https://my.url".
         "/tmp/croissant-editor-f76b4732c82d83daf858fae2cc0e590d352a4bceb781351243a03daab11f76bc"
     )
-    # Test typical CSV
+    # Test unescaped CSV
     if tsv.exists():
         tsv.unlink()
     with tsv.open("w") as f:


### PR DESCRIPTION
Add tab separated values to the Croissant editor.

Tab separated values are used for some datasets (e.g., FLORES 200). See #541 for related issue.