### PR TITLE
[Proposal] Make it easier to extend Croissant, add new fields in mlcroissant and document them.

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/core/dataclasses.py
+++ b/python/mlcroissant/mlcroissant/_src/core/dataclasses.py
@@ -23,7 +23,7 @@ class JsonldField(dataclasses.Field):
         input_types: list[Any],
         to_jsonld: Callable[[Context, Json], Any] | None,
         required: bool,
-        url: term.URIRef | Callable[[Context], term.URIRef] | None,
+        url: term.URIRef | Callable[[Context], term.URIRef],
     ):
         """Sets all args and kwargs."""
         super().__init__(*args)
@@ -44,7 +44,7 @@ class JsonldField(dataclasses.Field):
 
     def call_to_jsonld(self, ctx: Context, value: Any):
         """Calls `to_jsonld` in the field."""
-        if value and self.from_jsonld:
+        if value and self.to_jsonld:
             return self.to_jsonld(ctx, value)
         else:
             return value
@@ -52,9 +52,7 @@ class JsonldField(dataclasses.Field):
     def call_url(self, ctx: Context) -> term.URIRef:
         """Calls `jsonld` in the field."""
         url = self.url
-        if url is None:
-            return None
-        elif isinstance(url, term.URIRef):
+        if isinstance(url, term.URIRef):
             return url
         else:
             return url(ctx)
@@ -85,6 +83,8 @@ def jsonld_field(
         raise ValueError("cannot specify both default and default_factory")
     if not input_types or not isinstance(input_types, list):
         raise ValueError(f"input type should be a non-empty list. Got: {input_types}")
+    if not url:
+        raise ValueError(f"Provide a url. Got: {url}")
     return JsonldField(
         default,
         default_factory,

--- a/python/mlcroissant/mlcroissant/_src/core/dataclasses.py
+++ b/python/mlcroissant/mlcroissant/_src/core/dataclasses.py
@@ -1,0 +1,113 @@
+"""Utils to overload Python built-in dataclasses."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Callable, Literal
+
+from rdflib import term
+
+from mlcroissant._src.core.context import Context
+from mlcroissant._src.core.types import Json
+
+
+class JsonldField(dataclasses.Field):
+    """Overloads dataclasses.Field with JSON-LD-specific attributes."""
+
+    def __init__(
+        self,
+        *args,
+        cardinality: Literal["ONE", "MANY"],
+        description: str,
+        from_jsonld: Callable[[Context, Json], Any] | None,
+        input_types: list[Any],
+        to_jsonld: Callable[[Context, Json], Any] | None,
+        required: bool,
+        url: term.URIRef | Callable[[Context], term.URIRef] | None,
+    ):
+        """Sets all args and kwargs."""
+        super().__init__(*args)
+        self.cardinality = cardinality
+        self.description = description
+        self.from_jsonld = from_jsonld
+        self.input_types = input_types
+        self.to_jsonld = to_jsonld
+        self.required = required
+        self.url = url
+
+    def call_from_jsonld(self, ctx: Context, value: Any):
+        """Calls `from_jsonld` in the field."""
+        if value and self.from_jsonld:
+            return self.from_jsonld(ctx, value)
+        else:
+            return value
+
+    def call_to_jsonld(self, ctx: Context, value: Any):
+        """Calls `to_jsonld` in the field."""
+        if value and self.from_jsonld:
+            return self.to_jsonld(ctx, value)
+        else:
+            return value
+
+    def call_url(self, ctx: Context) -> term.URIRef:
+        """Calls `jsonld` in the field."""
+        url = self.url
+        if url is None:
+            return None
+        elif isinstance(url, term.URIRef):
+            return url
+        else:
+            return url(ctx)
+
+
+def jsonld_field(
+    default=dataclasses.MISSING,
+    default_factory=dataclasses.MISSING,
+    init=True,
+    repr=True,
+    hash=None,
+    compare=True,
+    metadata=None,
+    kw_only=dataclasses.MISSING,
+    cardinality="ONE",
+    description="",
+    from_jsonld=None,
+    input_types=None,
+    to_jsonld=None,
+    required=False,
+    url=None,
+):
+    """Overloads dataclasses.field with specific attributes."""
+    if (
+        default is not dataclasses.MISSING
+        and default_factory is not dataclasses.MISSING
+    ):
+        raise ValueError("cannot specify both default and default_factory")
+    if not input_types or not isinstance(input_types, list):
+        raise ValueError(f"input type should be a non-empty list. Got: {input_types}")
+    return JsonldField(
+        default,
+        default_factory,
+        init,
+        repr,
+        hash,
+        compare,
+        metadata,
+        kw_only,
+        cardinality=cardinality,
+        description=description,
+        from_jsonld=from_jsonld,
+        input_types=input_types,
+        to_jsonld=to_jsonld,
+        required=required,
+        url=url,
+    )
+
+
+def jsonld_fields(cls_or_instance) -> list[JsonldField]:
+    """Filters the JSON-LD fields."""
+    return [
+        field
+        for field in dataclasses.fields(cls_or_instance)
+        if isinstance(field, JsonldField)
+    ]

--- a/python/mlcroissant/mlcroissant/_src/core/uuid.py
+++ b/python/mlcroissant/mlcroissant/_src/core/uuid.py
@@ -18,6 +18,8 @@ def uuid_from_jsonld(jsonld: Json | None) -> str:
     if isinstance(jsonld, dict):
         uuid = jsonld.get("@id")
         return uuid_from_jsonld(uuid)
+    elif isinstance(jsonld, list):
+        return [uuid_from_jsonld(uuid) for uuid in jsonld]
     elif isinstance(jsonld, str):
         return uuid_to_jsonld(jsonld)
     return generate_uuid()

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Callable, Literal
 
-from rdflib import term
 from rdflib.namespace import SDO
 
 from mlcroissant._src.core import constants
 from mlcroissant._src.core.constants import ML_COMMONS
 from mlcroissant._src.core.context import Context
 from mlcroissant._src.core.data_types import check_expected_type
+from mlcroissant._src.core.dataclasses import jsonld_field
+from mlcroissant._src.core.dataclasses import jsonld_fields
+from mlcroissant._src.core.dataclasses import JsonldField
 from mlcroissant._src.core.json_ld import box_singleton_list
 from mlcroissant._src.core.json_ld import remove_empty_values
 from mlcroissant._src.core.json_ld import unbox_singleton_list
@@ -21,111 +22,8 @@ from mlcroissant._src.core.uuid import uuid_from_jsonld
 from mlcroissant._src.structure_graph.base_node import Node
 from mlcroissant._src.structure_graph.nodes.source import Source
 
-
-class JsonldField(dataclasses.Field):
-    """Overloads dataclasses.Field with JSON-LD-specific attributes."""
-
-    def __init__(
-        self,
-        *args,
-        cardinality: Literal["ONE", "MANY"],
-        description: str,
-        from_jsonld: Callable[[Context, Json], Any] | None,
-        input_types: list[Any],
-        to_jsonld: Callable[[Context, Json], Any] | None,
-        required: bool,
-        url: term.URIRef | Callable[[Context], term.URIRef] | None,
-    ):
-        """Sets all args and kwargs."""
-        super().__init__(*args)
-        self.cardinality = cardinality
-        self.description = description
-        self.from_jsonld = from_jsonld
-        self.input_types = input_types
-        self.to_jsonld = to_jsonld
-        self.required = required
-        self.url = url
-
-    def call_from_jsonld(self, ctx: Context, value: Any):
-        """Calls `from_jsonld` in the field."""
-        if value and self.from_jsonld:
-            return self.from_jsonld(ctx, value)
-        else:
-            return value
-
-    def call_to_jsonld(self, ctx: Context, value: Any):
-        """Calls `to_jsonld` in the field."""
-        if value and self.from_jsonld:
-            return self.to_jsonld(ctx, value)
-        else:
-            return value
-
-    def call_url(self, ctx: Context) -> term.URIRef:
-        """Calls `jsonld` in the field."""
-        url = self.url
-        if url is None:
-            return None
-        elif isinstance(url, term.URIRef):
-            return url
-        else:
-            return url(ctx)
-
-
 OriginalField = dataclasses.Field
 dataclasses.Field = JsonldField
-
-
-def jsonld_field(
-    default=dataclasses.MISSING,
-    default_factory=dataclasses.MISSING,
-    init=True,
-    repr=True,
-    hash=None,
-    compare=True,
-    metadata=None,
-    kw_only=dataclasses.MISSING,
-    cardinality="ONE",
-    description="",
-    from_jsonld=None,
-    input_types=None,
-    to_jsonld=None,
-    required=False,
-    url=None,
-):
-    """Overloads dataclasses.field with specific attributes."""
-    if (
-        default is not dataclasses.MISSING
-        and default_factory is not dataclasses.MISSING
-    ):
-        raise ValueError("cannot specify both default and default_factory")
-    if not input_types or not isinstance(input_types, list):
-        raise ValueError(f"input type should be a non-empty list. Got: {input_types}")
-    return JsonldField(
-        default,
-        default_factory,
-        init,
-        repr,
-        hash,
-        compare,
-        metadata,
-        kw_only,
-        cardinality=cardinality,
-        description=description,
-        from_jsonld=from_jsonld,
-        input_types=input_types,
-        to_jsonld=to_jsonld,
-        required=required,
-        url=url,
-    )
-
-
-def jsonld_fields(cls_or_instance) -> list[JsonldField]:
-    """Filters the JSON-LD fields."""
-    return [
-        field
-        for field in dataclasses.fields(cls_or_instance)
-        if isinstance(field, JsonldField)
-    ]
 
 
 @dataclasses.dataclass(eq=False, repr=False)

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object.py
@@ -3,34 +3,219 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Any
+from typing import Any, Callable, Literal
+
+from rdflib import term
+from rdflib.namespace import SDO
 
 from mlcroissant._src.core import constants
+from mlcroissant._src.core.constants import ML_COMMONS
 from mlcroissant._src.core.context import Context
 from mlcroissant._src.core.data_types import check_expected_type
 from mlcroissant._src.core.json_ld import box_singleton_list
 from mlcroissant._src.core.json_ld import remove_empty_values
 from mlcroissant._src.core.json_ld import unbox_singleton_list
 from mlcroissant._src.core.types import Json
+from mlcroissant._src.core.uuid import formatted_uuid_to_json
 from mlcroissant._src.core.uuid import uuid_from_jsonld
 from mlcroissant._src.structure_graph.base_node import Node
 from mlcroissant._src.structure_graph.nodes.source import Source
+
+
+class JsonldField(dataclasses.Field):
+    """Overloads dataclasses.Field with JSON-LD-specific attributes."""
+
+    def __init__(
+        self,
+        *args,
+        cardinality: Literal["ONE", "MANY"],
+        description: str,
+        from_jsonld: Callable[[Context, Json], Any] | None,
+        input_types: list[Any],
+        to_jsonld: Callable[[Context, Json], Any] | None,
+        required: bool,
+        url: term.URIRef | Callable[[Context], term.URIRef] | None,
+    ):
+        """Sets all args and kwargs."""
+        super().__init__(*args)
+        self.cardinality = cardinality
+        self.description = description
+        self.from_jsonld = from_jsonld
+        self.input_types = input_types
+        self.to_jsonld = to_jsonld
+        self.required = required
+        self.url = url
+
+    def call_from_jsonld(self, ctx: Context, value: Any):
+        """Calls `from_jsonld` in the field."""
+        if value and self.from_jsonld:
+            return self.from_jsonld(ctx, value)
+        else:
+            return value
+
+    def call_to_jsonld(self, ctx: Context, value: Any):
+        """Calls `to_jsonld` in the field."""
+        if value and self.from_jsonld:
+            return self.to_jsonld(ctx, value)
+        else:
+            return value
+
+    def call_url(self, ctx: Context) -> term.URIRef:
+        """Calls `jsonld` in the field."""
+        url = self.url
+        if url is None:
+            return None
+        elif isinstance(url, term.URIRef):
+            return url
+        else:
+            return url(ctx)
+
+
+OriginalField = dataclasses.Field
+dataclasses.Field = JsonldField
+
+
+def jsonld_field(
+    default=dataclasses.MISSING,
+    default_factory=dataclasses.MISSING,
+    init=True,
+    repr=True,
+    hash=None,
+    compare=True,
+    metadata=None,
+    kw_only=dataclasses.MISSING,
+    cardinality="ONE",
+    description="",
+    from_jsonld=None,
+    input_types=None,
+    to_jsonld=None,
+    required=False,
+    url=None,
+):
+    """Overloads dataclasses.field with specific attributes."""
+    if (
+        default is not dataclasses.MISSING
+        and default_factory is not dataclasses.MISSING
+    ):
+        raise ValueError("cannot specify both default and default_factory")
+    if not input_types or not isinstance(input_types, list):
+        raise ValueError(f"input type should be a non-empty list. Got: {input_types}")
+    return JsonldField(
+        default,
+        default_factory,
+        init,
+        repr,
+        hash,
+        compare,
+        metadata,
+        kw_only,
+        cardinality=cardinality,
+        description=description,
+        from_jsonld=from_jsonld,
+        input_types=input_types,
+        to_jsonld=to_jsonld,
+        required=required,
+        url=url,
+    )
+
+
+def jsonld_fields(cls_or_instance) -> list[JsonldField]:
+    """Filters the JSON-LD fields."""
+    return [
+        field
+        for field in dataclasses.fields(cls_or_instance)
+        if isinstance(field, JsonldField)
+    ]
 
 
 @dataclasses.dataclass(eq=False, repr=False)
 class FileObject(Node):
     """Nodes to describe a dataset FileObject (distribution)."""
 
-    content_url: str | None = None
-    content_size: str | None = None
-    contained_in: list[str] | None = None
-    description: str | None = None
-    encoding_format: str | None = None
-    md5: str | None = None
-    name: str = ""
-    same_as: list[str] | None = None
-    sha256: str | None = None
-    source: Source | None = None
+    content_url: str | None = jsonld_field(
+        default=None,
+        description=(
+            "Actual bytes of the media object, for example the image file or"
+            " video file."
+        ),
+        input_types=[SDO.URL],
+        url=SDO.contentUrl,
+    )
+    content_size: str | None = jsonld_field(
+        default=None,
+        description=(
+            "File size in (mega/kilo/…)bytes. Defaults to bytes if a unit is"
+            " not specified."
+        ),
+        input_types=[SDO.Text],
+        url=SDO.contentSize,
+    )
+    contained_in: list[str] | None = jsonld_field(
+        cardinality="MANY",
+        default_factory=list,
+        description=(
+            "Another FileObject or FileSet that this one is contained in, e.g.,"
+            " in the case of a file extracted from an archive. When this"
+            " property is present, the contentUrl is evaluated as a relative"
+            " path within the container object"
+        ),
+        from_jsonld=lambda ctx, contained_in: uuid_from_jsonld(contained_in),
+        input_types=[SDO.Text],
+        to_jsonld=lambda ctx, contained_in: [
+            formatted_uuid_to_json(ctx, uuid) for uuid in contained_in
+        ],
+        url=SDO.containedIn,
+    )
+    description: str | None = jsonld_field(
+        default=None,
+        input_types=[SDO.Text],
+        url=SDO.description,
+    )
+    encoding_format: str | None = jsonld_field(
+        default=None,
+        description="The format of the file, given as a mime type.",
+        input_types=[SDO.Text],
+        required=True,
+        url=SDO.encodingFormat,
+    )
+    md5: str | None = jsonld_field(
+        default=None,
+        input_types=[SDO.Text],
+        url=lambda ctx: ML_COMMONS(ctx).md5,
+    )
+    name: str = jsonld_field(
+        default=None,
+        description=(
+            "The name of the file.  As much as possible, the name should"
+            " reflect the name of the file as downloaded, including the file"
+            " extension. e.g. “images.zip”."
+        ),
+        input_types=[SDO.Text],
+        required=True,
+        url=SDO.name,
+    )
+    same_as: list[str] | None = jsonld_field(
+        cardinality="MANY",
+        default_factory=list,
+        description=(
+            "URL (or local name) of a FileObject with the same content, but in"
+            " a different format."
+        ),
+        input_types=[SDO.URL],
+        url=SDO.sameAs,
+    )
+    sha256: str | None = jsonld_field(
+        cardinality="ONE",
+        default=None,
+        description="Checksum for the file contents.",
+        input_types=[SDO.Text],
+        url=SDO.sha256,
+    )
+    source: Source | None = jsonld_field(
+        default=None,
+        input_types=[Source],
+        url=lambda ctx: ML_COMMONS(ctx).source,
+    )
 
     def __post_init__(self):
         """Checks arguments of the node."""
@@ -41,60 +226,50 @@ class FileObject(Node):
             if self.ctx and not self.ctx.is_live_dataset:
                 self.assert_has_exclusive_properties(["md5", "sha256"])
 
+    @classmethod
+    def _JSONLD_TYPE(cls, ctx: Context):
+        """Gets the class' JSON-LD @type."""
+        return constants.SCHEMA_ORG_FILE_OBJECT(ctx)
+
+    # [Proposal] This method would move to `Node`, as it's now generic.
     def to_json(self) -> Json:
         """Converts the `FileObject` to JSON."""
-        contained_in: Any = self.contained_in
-        if not self.ctx.is_v0() and contained_in:
-            contained_in = [{"@id": uuid} for uuid in contained_in]
-        contained_in = unbox_singleton_list(contained_in)
+        cls = self.__class__
+        jsonld = {
+            "@type": self.ctx.rdf.shorten_value(cls._JSONLD_TYPE(self.ctx)),
+            "@id": None if self.ctx.is_v0() else self.id,
+        }
+        for field in jsonld_fields(self):
+            url = field.call_url(self.ctx)
+            key = url.split("/")[-1]
+            value = getattr(self, field.name)
+            value = field.call_to_jsonld(self.ctx, value)
+            if field.cardinality == "MANY":
+                value = unbox_singleton_list(value)
+            jsonld[key] = value
+        return remove_empty_values(jsonld)
 
-        return remove_empty_values({
-            "@type": "sc:FileObject" if self.ctx.is_v0() else "cr:FileObject",
-            "@id": None if self.ctx.is_v0() else self.uuid,
-            "name": self.name,
-            "description": self.description,
-            "contentSize": self.content_size,
-            "contentUrl": self.content_url,
-            "containedIn": contained_in,
-            "encodingFormat": self.encoding_format,
-            "md5": self.md5,
-            "sameAs": unbox_singleton_list(self.same_as),
-            "sha256": self.sha256,
-            "source": self.source.to_json(ctx=self.ctx) if self.source else None,
-        })
-
+    # [Proposal] This method would move to `Node`, as it's now generic.
     @classmethod
-    def from_jsonld(
-        cls,
-        ctx: Context,
-        file_object: Json,
-    ) -> FileObject:
+    def from_jsonld(cls, ctx: Context, jsonld: Json) -> FileObject:
         """Creates a `FileObject` from JSON-LD."""
-        check_expected_type(
-            ctx.issues, file_object, constants.SCHEMA_ORG_FILE_OBJECT(ctx)
-        )
-        content_url = file_object.get(constants.SCHEMA_ORG_CONTENT_URL)
-        name = file_object.get(constants.SCHEMA_ORG_NAME, "")
-
-        contained_in = box_singleton_list(
-            file_object.get(constants.SCHEMA_ORG_CONTAINED_IN)
-        )
-        if contained_in is not None and not ctx.is_v0():
-            contained_in = [uuid_from_jsonld(source) for source in contained_in]
-        content_size = file_object.get(constants.SCHEMA_ORG_CONTENT_SIZE)
-        description = file_object.get(constants.SCHEMA_ORG_DESCRIPTION)
-        encoding_format = file_object.get(constants.SCHEMA_ORG_ENCODING_FORMAT)
+        check_expected_type(ctx, jsonld, cls._JSONLD_TYPE(ctx))
+        kwargs = {}
+        for field in jsonld_fields(cls):
+            url = field.call_url(ctx)
+            value = jsonld.get(url)
+            value = field.call_from_jsonld(ctx, value)
+            if field.cardinality == "MANY":
+                value = box_singleton_list(value)
+            if value:
+                kwargs[field.name] = value
+        # Normalize name to be at least an empty str:
+        kwargs["name"] = kwargs.get("name", "")
         return cls(
             ctx=ctx,
-            content_url=content_url,
-            content_size=content_size,
-            contained_in=contained_in,
-            description=description,
-            encoding_format=encoding_format,
-            md5=file_object.get(constants.SCHEMA_ORG_MD5(ctx)),
-            name=name,
-            same_as=box_singleton_list(file_object.get(constants.SCHEMA_ORG_SAME_AS)),
-            sha256=file_object.get(constants.SCHEMA_ORG_SHA256),
-            source=file_object.get(constants.ML_COMMONS_SOURCE(ctx)),
-            id=uuid_from_jsonld(file_object),
+            id=uuid_from_jsonld(jsonld),
+            **kwargs,
         )
+
+
+dataclasses.Field = OriginalField

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_object.py
@@ -23,13 +23,14 @@ from mlcroissant._src.structure_graph.base_node import Node
 from mlcroissant._src.structure_graph.nodes.source import Source
 
 OriginalField = dataclasses.Field
-dataclasses.Field = JsonldField
+dataclasses.Field = JsonldField  # type: ignore
 
 
 @dataclasses.dataclass(eq=False, repr=False)
 class FileObject(Node):
     """Nodes to describe a dataset FileObject (distribution)."""
 
+    # pytype: disable=annotation-type-mismatch
     content_url: str | None = jsonld_field(
         default=None,
         description=(
@@ -114,6 +115,7 @@ class FileObject(Node):
         input_types=[Source],
         url=lambda ctx: ML_COMMONS(ctx).source,
     )
+    # pytype: enable=annotation-type-mismatch
 
     def __post_init__(self):
         """Checks arguments of the node."""
@@ -151,7 +153,7 @@ class FileObject(Node):
     @classmethod
     def from_jsonld(cls, ctx: Context, jsonld: Json) -> FileObject:
         """Creates a `FileObject` from JSON-LD."""
-        check_expected_type(ctx, jsonld, cls._JSONLD_TYPE(ctx))
+        check_expected_type(ctx.issues, jsonld, cls._JSONLD_TYPE(ctx))
         kwargs = {}
         for field in jsonld_fields(cls):
             url = field.call_url(ctx)
@@ -170,4 +172,4 @@ class FileObject(Node):
         )
 
 
-dataclasses.Field = OriginalField
+dataclasses.Field = OriginalField  # type: ignore

--- a/python/mlcroissant/mlcroissant/scripts/cli.py
+++ b/python/mlcroissant/mlcroissant/scripts/cli.py
@@ -14,13 +14,11 @@ class Commands:
     VALIDATE = "validate"
 
 
-choices = set(
-    [
-        Commands.DOCUMENTATION,
-        Commands.LOAD,
-        Commands.VALIDATE,
-    ]
-)
+choices = set([
+    Commands.DOCUMENTATION,
+    Commands.LOAD,
+    Commands.VALIDATE,
+])
 
 
 def main():

--- a/python/mlcroissant/mlcroissant/scripts/cli.py
+++ b/python/mlcroissant/mlcroissant/scripts/cli.py
@@ -9,16 +9,18 @@ from absl import app
 class Commands:
     """Possible commands."""
 
-    FROM_HUGGINGFACE_TO_CROISSANT = "from_huggingface_to_croissant"
+    DOCUMENTATION = "documentation"
     LOAD = "load"
     VALIDATE = "validate"
 
 
-choices = set([
-    Commands.FROM_HUGGINGFACE_TO_CROISSANT,
-    Commands.LOAD,
-    Commands.VALIDATE,
-])
+choices = set(
+    [
+        Commands.DOCUMENTATION,
+        Commands.LOAD,
+        Commands.VALIDATE,
+    ]
+)
 
 
 def main():
@@ -28,12 +30,5 @@ def main():
     choice = sys.argv[1]
     if choice not in choices:
         raise ValueError(f"usage: mlcroissant {choices}. Got: `mlcroissant {choice}`")
-    if choice == Commands.FROM_HUGGINGFACE_TO_CROISSANT:
-        raise ValueError(
-            "This conversion script is deprecated. Please, use Hugging Face's API"
-            " endpoint:"
-            " https://datasets-server.huggingface.co/croissant?dataset={dataset} where"
-            " `dataset` is the ID the dataset on Hugging Face Hub."
-        )
     module = importlib.import_module(f"mlcroissant.scripts.{choice}")
     app.run(module.main)

--- a/python/mlcroissant/mlcroissant/scripts/documentation.py
+++ b/python/mlcroissant/mlcroissant/scripts/documentation.py
@@ -1,0 +1,89 @@
+"""Generates the dataset and yields the first example."""
+
+import dataclasses
+import datetime
+from typing import TypedDict
+
+from absl import app
+from absl import flags
+from absl import logging
+from etils import epath
+from rdflib import term
+
+import mlcroissant as mlc
+from mlcroissant._src.structure_graph.nodes.file_object import jsonld_fields
+from mlcroissant._src.structure_graph.nodes.file_object import JsonldField
+
+dataclasses.Field = JsonldField
+
+flags.DEFINE_string(
+    "output",
+    None,
+    "The output folder.",
+    required=True,
+)
+
+flags.mark_flag_as_required("output")
+
+
+FLAGS = flags.FLAGS
+
+
+class Url(TypedDict):
+    """TypedDict with `url` and `name`."""
+
+    url: str
+    name: str
+
+
+def main(argv):
+    """Main function launched by the script."""
+    del argv
+    output = epath.Path(FLAGS.output)
+    return documentation(output=output)
+
+
+def documentation(output: epath.Path):
+    """Creates the documentation."""
+    if output.exists():
+        logging.info(f"Path {output} already exists")
+        output = output / datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    output.mkdir(parents=True)
+    from jinja2 import Environment
+    from jinja2 import FileSystemLoader
+
+    loader = FileSystemLoader(epath.Path(__file__).parent / "templates")
+    env = Environment(loader=loader)
+    ctx = mlc.Context()
+    for cls in [mlc.FileObject]:
+        fields = []
+        for field in jsonld_fields(cls):
+            url = field.call_url(ctx)
+            url = Url(url=url, name=ctx.rdf.shorten_value(url))
+            input_types = []
+            for input_type in field.input_types:
+                if isinstance(input_type, term.URIRef):
+                    input_types.append(
+                        Url(url=str(input_type), name=ctx.rdf.shorten_value(input_type))
+                    )
+                else:
+                    input_types.append(Url(url=str(input_type), name=""))
+            details = {
+                "cardinality": field.cardinality,
+                "description": field.description,
+                "input_types": input_types,
+                "url": url,
+            }
+            fields.append(details)
+        data = {
+            "title": cls.__name__,
+            "fields": fields,
+        }
+        template = env.get_template("node.html")
+        file = output / f"{cls.__name__}.html"
+        file.write_text(template.render(data))
+    print(f"Wrote documentation to {output}")
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/python/mlcroissant/mlcroissant/scripts/documentation.py
+++ b/python/mlcroissant/mlcroissant/scripts/documentation.py
@@ -1,6 +1,5 @@
 """Generates the dataset and yields the first example."""
 
-import dataclasses
 import datetime
 from typing import TypedDict
 
@@ -12,9 +11,6 @@ from rdflib import term
 
 import mlcroissant as mlc
 from mlcroissant._src.structure_graph.nodes.file_object import jsonld_fields
-from mlcroissant._src.structure_graph.nodes.file_object import JsonldField
-
-dataclasses.Field = JsonldField
 
 flags.DEFINE_string(
     "output",

--- a/python/mlcroissant/mlcroissant/scripts/templates/node.html
+++ b/python/mlcroissant/mlcroissant/scripts/templates/node.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ title }} - Croissant 🥐</title>
+</head>
+<body>
+    <h1>{{ title }}</h1>
+    <table>
+        <tr>
+            <th>Property</th>
+            <th>Expected type</th>
+            <th>Cardinality</th>
+            <th>Description</th>
+        </tr>
+    {% for field in fields %}
+        <tr>
+            <td><a href="{{ field.url.url }}">{{ field.url.name }}</a></td>
+            <td>
+                {% for input_type in field.input_types %}
+                <a href="{{ input_type.url }}">{{ input_type.name }}</a>
+                {% endfor %}
+            </td>
+            <td>{{ field.cardinality }}</td>
+            <td>{{ field.description }}</td>
+        </tr>
+    {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
This PR primarily aims at facilitating the extensibility of Croissant in mlcroissant. When extending Croissant with the RAI fields (PR https://github.com/mlcommons/croissant/pull/553), we found out it was complex to add new fields: code has to be added at several place and it's not trivial to test. This PR would solve this issue by having all property definitions next to the class itself using the [`dataclasses`](https://docs.python.org/3/library/dataclasses.html) paradigm.

I started in this PR with the example of `FileObject`:

```python
class FileObject(Node):
    """Nodes to describe a dataset FileObject (distribution)."""

    content_url: str | None = jsonld_field(
        default=None,
        description="Actual bytes of the media object, for example the image file or video file.",
        input_types=[SDO.URL],
        url=SDO.contentUrl,
    )
```

Another potentially desirable consequence of this refacto is that we could generate schema.org-like documentation **as supported/implemented by mlcroissant**:
<img width="926" alt="image" src="https://github.com/mlcommons/croissant/assets/17081356/21eae587-03a5-4dad-9eed-effc8d6d5601">
