### PR TITLE
Editor RAI tab

### DIFF
--- a/editor/core/constants.py
+++ b/editor/core/constants.py
@@ -35,7 +35,7 @@ METADATA = "Metadata"
 RESOURCES = "Resources"
 RECORD_SETS = "Record Sets"
 RAI = "Extension: Responsible AI"
-TABS = [OVERVIEW, METADATA, RAI, RESOURCES, RECORD_SETS]
+TABS = [OVERVIEW, METADATA, RESOURCES, RECORD_SETS, RAI]
 
 NAMES_INFO = (
     "Names are used as identifiers. They are unique and cannot contain special"

--- a/editor/core/constants.py
+++ b/editor/core/constants.py
@@ -34,7 +34,8 @@ OVERVIEW = "Overview"
 METADATA = "Metadata"
 RESOURCES = "Resources"
 RECORD_SETS = "Record Sets"
-TABS = [OVERVIEW, METADATA, RESOURCES, RECORD_SETS]
+RAI = "Extension: Responsible AI"
+TABS = [OVERVIEW, METADATA, RAI, RESOURCES, RECORD_SETS]
 
 NAMES_INFO = (
     "Names are used as identifiers. They are unique and cannot contain special"

--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -195,26 +195,24 @@ class Metadata(Node):
     #  RAI extension attributes
     data_collection: str | None = None
     data_collection_type: str | None = None
-    data_collection_type_others: str | None = None
-    data_collection_missing: str | None = None
-    data_collection_raw: str | None = None
-    data_collection_timeframe_start: datetime.datetime | None = None
-    data_collection_timeframe_end: datetime.datetime | None = None
+    data_collection_missing_data: str | None = None
+    data_collection_raw_data: str | None = None
+    data_collection_timeframe: datetime.datetime | None = None
     data_preprocessing_imputation: str | None = None
     data_preprocessing_protocol: list[str] = None
     data_preprocessing_manipulation: str | None = None
     data_annotation_protocol: str | None = None
     data_annotation_platform: str | None = None
     data_annotation_analysis: str | None = None
-    data_annotation_per_item: str | None = None
-    data_annotation_demographics: str | None = None
-    data_annotation_tools: str | None = None
+    annotation_per_item: str | None = None
+    annotator_demographics: str | None = None
+    machine_annotation_tools: str | None = None
     data_biases: list[str] = None
     data_use_cases: list[str] = None
-    data_limitation: list[str] = None
+    data_limitations: list[str] = None
     data_social_impact: str | None = None
-    data_sensitive: list[str] = None
-    data_maintenance: str | None = None
+    personal_sensitive_information: list[str] = None
+    data_release_maintenance_plan: str | None = None
     uuid: str | None = None
     url: str = ""
     distribution: list[FileObject | FileSet] = dataclasses.field(default_factory=list)

--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -213,7 +213,6 @@ class Metadata(Node):
     data_social_impact: str | None = None
     personal_sensitive_information: list[str] = None
     data_release_maintenance_plan: str | None = None
-    uuid: str | None = None
     url: str = ""
     distribution: list[FileObject | FileSet] = dataclasses.field(default_factory=list)
     record_sets: list[RecordSet] = dataclasses.field(default_factory=list)

--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -198,9 +198,9 @@ class Metadata(Node):
     data_collection_missing_data: str | None = None
     data_collection_raw_data: str | None = None
     data_collection_timeframe: datetime.datetime | None = None
-    data_preprocessing_imputation: str | None = None
+    data_imputation_protocol: str | None = None
     data_preprocessing_protocol: list[str] = None
-    data_preprocessing_manipulation: str | None = None
+    data_manipulation_protocol: str | None = None
     data_annotation_protocol: str | None = None
     data_annotation_platform: str | None = None
     data_annotation_analysis: str | None = None

--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -190,11 +190,32 @@ class Metadata(Node):
     description: str | None = None
     cite_as: str | None = None
     creators: list[mlc.Person] = dataclasses.field(default_factory=list)
-    data_biases: str | None = None
-    data_collection: str | None = None
     date_published: datetime.datetime | None = None
     license: str | None = ""
-    personal_sensitive_information: str | None = None
+    #  RAI extension attributes
+    data_collection: str | None = None
+    data_collection_type: str | None = None
+    data_collection_type_others: str | None = None
+    data_collection_missing: str | None = None
+    data_collection_raw: str | None = None
+    data_collection_timeframe_start: datetime.datetime | None = None
+    data_collection_timeframe_end: datetime.datetime | None = None
+    data_preprocessing_imputation: str | None = None
+    data_preprocessing_protocol: list[str] = None
+    data_preprocessing_manipulation: str | None = None
+    data_annotation_protocol: str | None = None
+    data_annotation_platform: str | None = None
+    data_annotation_analysis: str | None = None
+    data_annotation_per_item: str | None = None
+    data_annotation_demographics: str | None = None
+    data_annotation_tools: str | None = None
+    data_biases: list[str] = None
+    data_use_cases: list[str] = None
+    data_limitation: list[str] = None
+    data_social_impact: str | None = None
+    data_sensitive: list[str] = None
+    data_maintenance: str | None = None
+    uuid: str | None = None
     url: str = ""
     distribution: list[FileObject | FileSet] = dataclasses.field(default_factory=list)
     record_sets: list[RecordSet] = dataclasses.field(default_factory=list)

--- a/editor/events/rai.py
+++ b/editor/events/rai.py
@@ -17,9 +17,9 @@ class RaiEvent(enum.Enum):
     RAI_DATA_COLLECTION_MISSING_DATA = "RAI_DATA_COLLECTION_MISSING_DATA"
     RAI_DATA_COLLECTION_RAW = "RAI_DATA_COLLECTION_RAW"
     RAI_DATA_COLLECTION_TIMEFRAME = "RAI_DATA_COLLECTION_TIMEFRAME"
-    RAI_DATA_PREPROCESSING_IMPUTATION = "RAI_DATA_PREPROCESSING_IMPUTATION"
+    RAI_DATA_IMPUTATION_PROTOCOL = "RAI_DATA_IMPUTATION_PROTOCOL"
     RAI_DATA_PREPROCESSING_PROTOCOL = " RAI_DATA_PREPROCESSING_PROTOCOL"
-    RAI_DATA_PREPROCESSING_MANIPULATION = "RAI_DATA_PREPROCESSING_MANIPULATIO"
+    RAI_DATA_MANIPULATION_PROTOCOL = "RAI_DATA_MANIPULATION_PROTOCOL"
     RAI_DATA_ANNOTATION_PROTOCOL = "RAI_DATA_ANNOTATION_PROTOCOL"
     RAI_DATA_ANNOTATION_PLATFORM = "RAI_DATA_ANNOTATION_PLATFORM"
     RAI_DATA_ANNOTATION_ANALYSIS = "RAI_DATA_ANNOTATION_ANALYSIS"
@@ -39,20 +39,15 @@ def handle_rai_change(event: RaiEvent, Metadata: Metadata, key: str):
         Metadata.data_collection = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_TYPE:
         Metadata.data_collection_type = st.session_state[key]
-    if event == RaiEvent.RAI_DATA_COLLECTION_TYPE_OTHERS:
-        ## To implement
-        pass
     if event == RaiEvent.RAI_DATA_COLLECTION_MISSING_DATA:
         Metadata.data_collection_missing_data = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_RAW:
         Metadata.data_collection_raw_data = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME:
-        date = st.session_state[key]
-        Metadata.data_collection_timeframe = datetime.datetime(
-            date.year, date.month, date.day
-        )
-    if event == RaiEvent.RAI_DATA_PREPROCESSING_IMPUTATION:
-        Metadata.data_preprocessing_imputation = st.session_state[key]
+        # To do
+        pass
+    if event == RaiEvent.RAI_DATA_IMPUTATION_PROTOCOL:
+        Metadata.data_imputation_protocol = st.session_state[key]
     if event == RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL:
         if Metadata.data_preprocessing_protocol:
             index = key.split("_")[-1]
@@ -60,8 +55,8 @@ def handle_rai_change(event: RaiEvent, Metadata: Metadata, key: str):
         else:
             Metadata.data_preprocessing_protocol = []
             Metadata.data_preprocessing_protocol.append(st.session_state[key])
-    if event == RaiEvent.RAI_DATA_PREPROCESSING_MANIPULATION:
-        Metadata.data_preprocessing_manipulation = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_MANIPULATION_PROTOCOL:
+        Metadata.data_manipulation_protocol = st.session_state[key]
     if event == RaiEvent.RAI_DATA_ANNOTATION_PROTOCOL:
 
         Metadata.data_annotation_protocol = st.session_state[key]

--- a/editor/events/rai.py
+++ b/editor/events/rai.py
@@ -13,7 +13,6 @@ class RaiEvent(enum.Enum):
 
     RAI_DATA_COLLECTION = "RAI_DATA_COLLECTION"
     RAI_DATA_COLLECTION_TYPE = "RAI_DATA_COLLECTION_TYPE"
-    RAI_DATA_COLLECTION_TYPE_OTHERS = "RAI_DATA_COLLECTION_TYPE_OTHERS"
     RAI_DATA_COLLECTION_MISSING_DATA = "RAI_DATA_COLLECTION_MISSING_DATA"
     RAI_DATA_COLLECTION_RAW = "RAI_DATA_COLLECTION_RAW"
     RAI_DATA_COLLECTION_TIMEFRAME = "RAI_DATA_COLLECTION_TIMEFRAME"
@@ -34,9 +33,9 @@ class RaiEvent(enum.Enum):
     RAI_MAINTENANCE = "RAI_MAINTENANCE"
 
 
-def handle_rai_change(event: RaiEvent, metadata: Metadata, key: str):
+def handle_rai_change(event: RaiEvent, metadata: Metadata, key: str, index: int = 0):
     ## If widget is 1-to-many we first get the index to proper update them
-    index = get_widget_cadinality(key)
+    #index = get_widget_cadinality(key)
     if event == RaiEvent.RAI_DATA_COLLECTION:
         metadata.data_collection = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_TYPE:
@@ -52,7 +51,7 @@ def handle_rai_change(event: RaiEvent, metadata: Metadata, key: str):
         metadata.data_imputation_protocol = st.session_state[key]
     if event == RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL:
         if metadata.data_preprocessing_protocol:
-            metadata.data_preprocessing_protocol[int(index)] = st.session_state[key]
+            metadata.data_preprocessing_protocol[index] = st.session_state[key]
         else:
             metadata.data_preprocessing_protocol = []
             metadata.data_preprocessing_protocol.append(st.session_state[key])

--- a/editor/events/rai.py
+++ b/editor/events/rai.py
@@ -35,7 +35,6 @@ class RaiEvent(enum.Enum):
 
 def handle_rai_change(event: RaiEvent, metadata: Metadata, key: str, index: int = 0):
     ## If widget is 1-to-many we first get the index to proper update them
-    # index = get_widget_cadinality(key)
     if event == RaiEvent.RAI_DATA_COLLECTION:
         metadata.data_collection = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_TYPE:
@@ -46,6 +45,7 @@ def handle_rai_change(event: RaiEvent, metadata: Metadata, key: str, index: int 
         metadata.data_collection_raw_data = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME:
         # To do
+        raise NotImplementedError("Data collectiom timeframe range still not implemented")
         pass
     if event == RaiEvent.RAI_DATA_IMPUTATION_PROTOCOL:
         metadata.data_imputation_protocol = st.session_state[key]

--- a/editor/events/rai.py
+++ b/editor/events/rai.py
@@ -1,0 +1,119 @@
+import datetime
+import enum
+
+import streamlit as st
+
+from core.names import find_unique_name
+from core.state import Metadata
+import mlcroissant as mlc
+
+
+class RaiEvent(enum.Enum):
+    """Event that triggers a Rai change."""
+
+    RAI_DATA_COLLECTION = "RAI_DATA_COLLECTION"
+    RAI_DATA_COLLECTION_TYPE = "RAI_DATA_COLLECTION_TYPE"
+    RAI_DATA_COLLECTION_TYPE_OTHERS = "RAI_DATA_COLLECTION_TYPE_OTHERS"
+    RAI_DATA_COLLECTION_MISSING_DATA = "RAI_DATA_COLLECTION_MISSING_DATA"
+    RAI_DATA_COLLECTION_RAW = "RAI_DATA_COLLECTION_RAW"
+    RAI_DATA_COLLECTION_TIMEFRAME_START = "RAI_DATA_COLLECTION_TIMEFRAME_START"
+    RAI_DATA_COLLECTION_TIMEFRAME_END = "RAI_DATA_COLLECTION_TIMEFRAME_END"
+    RAI_DATA_PREPROCESSING_IMPUTATION = "RAI_DATA_PREPROCESSING_IMPUTATION"
+    RAI_DATA_PREPROCESSING_PROTOCOL = " RAI_DATA_PREPROCESSING_PROTOCOL"
+    RAI_DATA_PREPROCESSING_MANIPULATION = "RAI_DATA_PREPROCESSING_MANIPULATIO"
+    RAI_DATA_ANNOTATION_PROTOCOL = "RAI_DATA_ANNOTATION_PROTOCOL"
+    RAI_DATA_ANNOTATION_PLATFORM = "RAI_DATA_ANNOTATION_PLATFORM"
+    RAI_DATA_ANNOTATION_ANALYSIS = "RAI_DATA_ANNOTATION_ANALYSIS"
+    RAI_DATA_ANNOTATION_PER_ITEM = "RAI_DATA_ANNOTATION_PERI_TEM"
+    RAI_DATA_ANNOTATION_DEMOGRAPHICS = "RAI_DATA_ANNOTATION_DEMOGRAPHICS"
+    RAI_DATA_ANNOTATION_TOOLS = "RAI_DATA_ANNOTATION_TOOLS"
+    RAI_DATA_USE_CASES = "RAI_DATA_USECASES"
+    RAI_DATA_BIAS = "RAI_DATA_BIAS"
+    RAI_DATA_LIMITATION = "RAI_DATA_LIMITATION"
+    RAI_DATA_SOCIAL_IMPACT = "RAI_DATA_SOCIAL_IMPACT"
+    RAI_SENSITIVE = "RAI_SENSITIVE"
+    RAI_MAINTENANCE = "RAI_MAINTENANCE"
+
+
+def handle_rai_change(event: RaiEvent, Metadata: Metadata, key: str):
+    if event == RaiEvent.RAI_DATA_COLLECTION:
+        Metadata.data_collection = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_COLLECTION_TYPE:
+        Metadata.data_collection_type = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_COLLECTION_TYPE_OTHERS:
+        Metadata.data_collection_type_others = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_COLLECTION_MISSING_DATA:
+        Metadata.data_collection_missing = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_COLLECTION_RAW:
+        Metadata.data_collection_raw = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME_START:
+        date = st.session_state[key]
+        Metadata.data_collection_timeframe_start = datetime.datetime(
+            date.year, date.month, date.day
+        )
+    if event == RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME_END:
+        date = st.session_state[key]
+        Metadata.data_collection_timeframe_end = datetime.datetime(
+            date.year, date.month, date.day
+        )
+    if event == RaiEvent.RAI_DATA_PREPROCESSING_IMPUTATION:
+        Metadata.data_preprocessing_imputation = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL:
+        if Metadata.data_preprocessing_protocol:
+            index = key.split("_")[-1]
+            Metadata.data_preprocessing_protocol[int(index)] = st.session_state[key]
+        else:
+            Metadata.data_preprocessing_protocol = []
+            Metadata.data_preprocessing_protocol.append(st.session_state[key])
+    if event == RaiEvent.RAI_DATA_PREPROCESSING_MANIPULATION:
+        Metadata.data_preprocessing_manipulation = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_ANNOTATION_PROTOCOL:
+
+        Metadata.data_annotation_protocol = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_ANNOTATION_PLATFORM:
+        Metadata.data_annotation_platform = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_ANNOTATION_ANALYSIS:
+        Metadata.data_annotation_analysis = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_ANNOTATION_PER_ITEM:
+        Metadata.data_annotation_per_item = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_ANNOTATION_DEMOGRAPHICS:
+        Metadata.data_annotation_demographics = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_ANNOTATION_TOOLS:
+        Metadata.data_annotation_tools = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_USE_CASES:
+
+        if Metadata.data_use_cases:
+            index = key.split("_")[-1]
+            Metadata.data_use_cases[int(index)] = st.session_state[key]
+        else:
+            Metadata.data_use_cases = []
+            Metadata.data_use_cases.append(st.session_state[key])
+
+    if event == RaiEvent.RAI_DATA_BIAS:
+
+        if Metadata.data_biases:
+            index = key.split("_")[-1]
+            Metadata.data_biases[int(index)] = st.session_state[key]
+        else:
+            Metadata.data_biases = []
+            Metadata.data_biases.append(st.session_state[key])
+
+    if event == RaiEvent.RAI_DATA_LIMITATION:
+        if Metadata.data_limitation:
+            index = key.split("_")[-1]
+            Metadata.data_limitation[int(index)] = st.session_state[key]
+        else:
+            Metadata.data_limitation = []
+            Metadata.data_limitation.append(st.session_state[key])
+    if event == RaiEvent.RAI_DATA_SOCIAL_IMPACT:
+        Metadata.data_social_impact = st.session_state[key]
+    if event == RaiEvent.RAI_SENSITIVE:
+
+        if Metadata.data_sensitive:
+            index = key.split("_")[-1]
+            Metadata.data_sensitive[int(index)] = st.session_state[key]
+        else:
+            Metadata.data_sensitive = []
+            Metadata.data_sensitive.append(st.session_state[key])
+    if event == RaiEvent.RAI_MAINTENANCE:
+        Metadata.data_maintenance = st.session_state[key]

--- a/editor/events/rai.py
+++ b/editor/events/rai.py
@@ -72,8 +72,7 @@ def handle_rai_change(event: RaiEvent, metadata: Metadata, key: str):
     if event == RaiEvent.RAI_DATA_ANNOTATION_TOOLS:
         metadata.machine_annotation_tools = st.session_state[key]
     if event == RaiEvent.RAI_DATA_USE_CASES:
-        print(index)
-        print(st.session_state[key])
+
         if metadata.data_use_cases:
             metadata.data_use_cases[int(index)] = st.session_state[key]
         else:
@@ -105,6 +104,7 @@ def handle_rai_change(event: RaiEvent, metadata: Metadata, key: str):
             metadata.personal_sensitive_information.append(st.session_state[key])
     if event == RaiEvent.RAI_MAINTENANCE:
         metadata.data_release_maintenance_plan = st.session_state[key]
+
 
 def get_widget_cadinality(key: str):
     return key.split("_")[-1]

--- a/editor/events/rai.py
+++ b/editor/events/rai.py
@@ -35,7 +35,7 @@ class RaiEvent(enum.Enum):
 
 def handle_rai_change(event: RaiEvent, metadata: Metadata, key: str, index: int = 0):
     ## If widget is 1-to-many we first get the index to proper update them
-    #index = get_widget_cadinality(key)
+    # index = get_widget_cadinality(key)
     if event == RaiEvent.RAI_DATA_COLLECTION:
         metadata.data_collection = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_TYPE:

--- a/editor/events/rai.py
+++ b/editor/events/rai.py
@@ -45,7 +45,9 @@ def handle_rai_change(event: RaiEvent, metadata: Metadata, key: str, index: int 
         metadata.data_collection_raw_data = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME:
         # To do
-        raise NotImplementedError("Data collectiom timeframe range still not implemented")
+        raise NotImplementedError(
+            "Data collectiom timeframe range still not implemented"
+        )
         pass
     if event == RaiEvent.RAI_DATA_IMPUTATION_PROTOCOL:
         metadata.data_imputation_protocol = st.session_state[key]

--- a/editor/events/rai.py
+++ b/editor/events/rai.py
@@ -16,8 +16,7 @@ class RaiEvent(enum.Enum):
     RAI_DATA_COLLECTION_TYPE_OTHERS = "RAI_DATA_COLLECTION_TYPE_OTHERS"
     RAI_DATA_COLLECTION_MISSING_DATA = "RAI_DATA_COLLECTION_MISSING_DATA"
     RAI_DATA_COLLECTION_RAW = "RAI_DATA_COLLECTION_RAW"
-    RAI_DATA_COLLECTION_TIMEFRAME_START = "RAI_DATA_COLLECTION_TIMEFRAME_START"
-    RAI_DATA_COLLECTION_TIMEFRAME_END = "RAI_DATA_COLLECTION_TIMEFRAME_END"
+    RAI_DATA_COLLECTION_TIMEFRAME = "RAI_DATA_COLLECTION_TIMEFRAME"
     RAI_DATA_PREPROCESSING_IMPUTATION = "RAI_DATA_PREPROCESSING_IMPUTATION"
     RAI_DATA_PREPROCESSING_PROTOCOL = " RAI_DATA_PREPROCESSING_PROTOCOL"
     RAI_DATA_PREPROCESSING_MANIPULATION = "RAI_DATA_PREPROCESSING_MANIPULATIO"
@@ -41,19 +40,15 @@ def handle_rai_change(event: RaiEvent, Metadata: Metadata, key: str):
     if event == RaiEvent.RAI_DATA_COLLECTION_TYPE:
         Metadata.data_collection_type = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_TYPE_OTHERS:
-        Metadata.data_collection_type_others = st.session_state[key]
+        ## To implement
+        pass
     if event == RaiEvent.RAI_DATA_COLLECTION_MISSING_DATA:
-        Metadata.data_collection_missing = st.session_state[key]
+        Metadata.data_collection_missing_data = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_RAW:
-        Metadata.data_collection_raw = st.session_state[key]
-    if event == RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME_START:
+        Metadata.data_collection_raw_data = st.session_state[key]
+    if event == RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME:
         date = st.session_state[key]
-        Metadata.data_collection_timeframe_start = datetime.datetime(
-            date.year, date.month, date.day
-        )
-    if event == RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME_END:
-        date = st.session_state[key]
-        Metadata.data_collection_timeframe_end = datetime.datetime(
+        Metadata.data_collection_timeframe = datetime.datetime(
             date.year, date.month, date.day
         )
     if event == RaiEvent.RAI_DATA_PREPROCESSING_IMPUTATION:
@@ -75,11 +70,11 @@ def handle_rai_change(event: RaiEvent, Metadata: Metadata, key: str):
     if event == RaiEvent.RAI_DATA_ANNOTATION_ANALYSIS:
         Metadata.data_annotation_analysis = st.session_state[key]
     if event == RaiEvent.RAI_DATA_ANNOTATION_PER_ITEM:
-        Metadata.data_annotation_per_item = st.session_state[key]
+        Metadata.annotation_per_item = st.session_state[key]
     if event == RaiEvent.RAI_DATA_ANNOTATION_DEMOGRAPHICS:
-        Metadata.data_annotation_demographics = st.session_state[key]
+        Metadata.annotator_demographics = st.session_state[key]
     if event == RaiEvent.RAI_DATA_ANNOTATION_TOOLS:
-        Metadata.data_annotation_tools = st.session_state[key]
+        Metadata.machine_annotation_tools = st.session_state[key]
     if event == RaiEvent.RAI_DATA_USE_CASES:
 
         if Metadata.data_use_cases:
@@ -99,21 +94,21 @@ def handle_rai_change(event: RaiEvent, Metadata: Metadata, key: str):
             Metadata.data_biases.append(st.session_state[key])
 
     if event == RaiEvent.RAI_DATA_LIMITATION:
-        if Metadata.data_limitation:
+        if Metadata.data_limitations:
             index = key.split("_")[-1]
-            Metadata.data_limitation[int(index)] = st.session_state[key]
+            Metadata.data_limitations[int(index)] = st.session_state[key]
         else:
-            Metadata.data_limitation = []
-            Metadata.data_limitation.append(st.session_state[key])
+            Metadata.data_limitations = []
+            Metadata.data_limitations.append(st.session_state[key])
     if event == RaiEvent.RAI_DATA_SOCIAL_IMPACT:
         Metadata.data_social_impact = st.session_state[key]
     if event == RaiEvent.RAI_SENSITIVE:
 
-        if Metadata.data_sensitive:
+        if Metadata.personal_sensitive_information:
             index = key.split("_")[-1]
-            Metadata.data_sensitive[int(index)] = st.session_state[key]
+            Metadata.personal_sensitive_information[int(index)] = st.session_state[key]
         else:
-            Metadata.data_sensitive = []
-            Metadata.data_sensitive.append(st.session_state[key])
+            Metadata.personal_sensitive_information = []
+            Metadata.personal_sensitive_information.append(st.session_state[key])
     if event == RaiEvent.RAI_MAINTENANCE:
-        Metadata.data_maintenance = st.session_state[key]
+        Metadata.data_release_maintenance_plan = st.session_state[key]

--- a/editor/events/rai.py
+++ b/editor/events/rai.py
@@ -34,76 +34,77 @@ class RaiEvent(enum.Enum):
     RAI_MAINTENANCE = "RAI_MAINTENANCE"
 
 
-def handle_rai_change(event: RaiEvent, Metadata: Metadata, key: str):
+def handle_rai_change(event: RaiEvent, metadata: Metadata, key: str):
+    ## If widget is 1-to-many we first get the index to proper update them
+    index = get_widget_cadinality(key)
     if event == RaiEvent.RAI_DATA_COLLECTION:
-        Metadata.data_collection = st.session_state[key]
+        metadata.data_collection = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_TYPE:
-        Metadata.data_collection_type = st.session_state[key]
+        metadata.data_collection_type = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_MISSING_DATA:
-        Metadata.data_collection_missing_data = st.session_state[key]
+        metadata.data_collection_missing_data = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_RAW:
-        Metadata.data_collection_raw_data = st.session_state[key]
+        metadata.data_collection_raw_data = st.session_state[key]
     if event == RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME:
         # To do
         pass
     if event == RaiEvent.RAI_DATA_IMPUTATION_PROTOCOL:
-        Metadata.data_imputation_protocol = st.session_state[key]
+        metadata.data_imputation_protocol = st.session_state[key]
     if event == RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL:
-        if Metadata.data_preprocessing_protocol:
-            index = key.split("_")[-1]
-            Metadata.data_preprocessing_protocol[int(index)] = st.session_state[key]
+        if metadata.data_preprocessing_protocol:
+            metadata.data_preprocessing_protocol[int(index)] = st.session_state[key]
         else:
-            Metadata.data_preprocessing_protocol = []
-            Metadata.data_preprocessing_protocol.append(st.session_state[key])
+            metadata.data_preprocessing_protocol = []
+            metadata.data_preprocessing_protocol.append(st.session_state[key])
     if event == RaiEvent.RAI_DATA_MANIPULATION_PROTOCOL:
-        Metadata.data_manipulation_protocol = st.session_state[key]
+        metadata.data_manipulation_protocol = st.session_state[key]
     if event == RaiEvent.RAI_DATA_ANNOTATION_PROTOCOL:
 
-        Metadata.data_annotation_protocol = st.session_state[key]
+        metadata.data_annotation_protocol = st.session_state[key]
     if event == RaiEvent.RAI_DATA_ANNOTATION_PLATFORM:
-        Metadata.data_annotation_platform = st.session_state[key]
+        metadata.data_annotation_platform = st.session_state[key]
     if event == RaiEvent.RAI_DATA_ANNOTATION_ANALYSIS:
-        Metadata.data_annotation_analysis = st.session_state[key]
+        metadata.data_annotation_analysis = st.session_state[key]
     if event == RaiEvent.RAI_DATA_ANNOTATION_PER_ITEM:
-        Metadata.annotation_per_item = st.session_state[key]
+        metadata.annotation_per_item = st.session_state[key]
     if event == RaiEvent.RAI_DATA_ANNOTATION_DEMOGRAPHICS:
-        Metadata.annotator_demographics = st.session_state[key]
+        metadata.annotator_demographics = st.session_state[key]
     if event == RaiEvent.RAI_DATA_ANNOTATION_TOOLS:
-        Metadata.machine_annotation_tools = st.session_state[key]
+        metadata.machine_annotation_tools = st.session_state[key]
     if event == RaiEvent.RAI_DATA_USE_CASES:
-
-        if Metadata.data_use_cases:
-            index = key.split("_")[-1]
-            Metadata.data_use_cases[int(index)] = st.session_state[key]
+        print(index)
+        print(st.session_state[key])
+        if metadata.data_use_cases:
+            metadata.data_use_cases[int(index)] = st.session_state[key]
         else:
-            Metadata.data_use_cases = []
-            Metadata.data_use_cases.append(st.session_state[key])
+            metadata.data_use_cases = []
+            metadata.data_use_cases.append(st.session_state[key])
 
     if event == RaiEvent.RAI_DATA_BIAS:
 
-        if Metadata.data_biases:
-            index = key.split("_")[-1]
-            Metadata.data_biases[int(index)] = st.session_state[key]
+        if metadata.data_biases:
+            metadata.data_biases[int(index)] = st.session_state[key]
         else:
-            Metadata.data_biases = []
-            Metadata.data_biases.append(st.session_state[key])
+            metadata.data_biases = []
+            metadata.data_biases.append(st.session_state[key])
 
     if event == RaiEvent.RAI_DATA_LIMITATION:
-        if Metadata.data_limitations:
-            index = key.split("_")[-1]
-            Metadata.data_limitations[int(index)] = st.session_state[key]
+        if metadata.data_limitations:
+            metadata.data_limitations[int(index)] = st.session_state[key]
         else:
-            Metadata.data_limitations = []
-            Metadata.data_limitations.append(st.session_state[key])
+            metadata.data_limitations = []
+            metadata.data_limitations.append(st.session_state[key])
     if event == RaiEvent.RAI_DATA_SOCIAL_IMPACT:
-        Metadata.data_social_impact = st.session_state[key]
+        metadata.data_social_impact = st.session_state[key]
     if event == RaiEvent.RAI_SENSITIVE:
 
-        if Metadata.personal_sensitive_information:
-            index = key.split("_")[-1]
-            Metadata.personal_sensitive_information[int(index)] = st.session_state[key]
+        if metadata.personal_sensitive_information:
+            metadata.personal_sensitive_information[int(index)] = st.session_state[key]
         else:
-            Metadata.personal_sensitive_information = []
-            Metadata.personal_sensitive_information.append(st.session_state[key])
+            metadata.personal_sensitive_information = []
+            metadata.personal_sensitive_information.append(st.session_state[key])
     if event == RaiEvent.RAI_MAINTENANCE:
-        Metadata.data_release_maintenance_plan = st.session_state[key]
+        metadata.data_release_maintenance_plan = st.session_state[key]
+
+def get_widget_cadinality(key: str):
+    return key.split("_")[-1]

--- a/editor/views/metadata.py
+++ b/editor/views/metadata.py
@@ -17,6 +17,7 @@ def render_metadata():
     with col2.expander("", expanded=True):
         st.info("**Instructions to fill metadata attributes**.")
 
+
 def _render_generic_metadata(metadata: Metadata):
     """Renders all non-RAI generic metadata."""
     index = find_license_index(metadata.license)

--- a/editor/views/metadata.py
+++ b/editor/views/metadata.py
@@ -14,50 +14,8 @@ def render_metadata():
     col1, col2 = st.columns([1, 1])
     with col1.expander("**Generic metadata**", expanded=True):
         _render_generic_metadata(metadata)
-    with col2.expander("**Responsible AI (RAI) metadata**", expanded=True):
-        _render_rai_metadata(metadata)
-
-
-def _render_rai_metadata(metadata: Metadata):
-    """Renders RAI (Responsible AI) metadata."""
-    key = "metadata-data-collection"
-    st.text_area(
-        label=(
-            "**Data collection**. Key stages of the data collection process encourage"
-            " its creators to reflect on the process and improves understanding for"
-            " users."
-        ),
-        key=key,
-        value=metadata.data_collection,
-        on_change=handle_metadata_change,
-        args=(MetadataEvent.DATA_COLLECTION, metadata, key),
-    )
-    key = "metadata-data-biases"
-    st.text_area(
-        label=(
-            "**Data biases**. Involves understanding the potential risks associated"
-            " with data usage and to prevent unintended and potentially harmful"
-            " consequences that may arise from using models trained on or evaluated"
-            " with the respective data."
-        ),
-        key=key,
-        value=metadata.data_biases,
-        on_change=handle_metadata_change,
-        args=(MetadataEvent.DATA_BIASES, metadata, key),
-    )
-    key = "metadata-personal-sensitive-information"
-    st.text_area(
-        label=(
-            "**Personal sensitive information**. Personal and sensitive information, if"
-            " contained within the dataset, can play an important role in the"
-            " mitigation of any risks and the responsible use of the datasets."
-        ),
-        key=key,
-        value=metadata.personal_sensitive_information,
-        on_change=handle_metadata_change,
-        args=(MetadataEvent.PERSONAL_SENSITIVE_INFORMATION, metadata, key),
-    )
-
+    with col2.expander("", expanded=True):
+        st.info("**Instructions to fill metadata attributes**.")
 
 def _render_generic_metadata(metadata: Metadata):
     """Renders all non-RAI generic metadata."""

--- a/editor/views/metadata.py
+++ b/editor/views/metadata.py
@@ -14,8 +14,6 @@ def render_metadata():
     col1, col2 = st.columns([1, 1])
     with col1.expander("**Generic metadata**", expanded=True):
         _render_generic_metadata(metadata)
-    with col2.expander("", expanded=True):
-        st.info("**Instructions to fill metadata attributes**.")
 
 
 def _render_generic_metadata(metadata: Metadata):

--- a/editor/views/rai.py
+++ b/editor/views/rai.py
@@ -37,7 +37,7 @@ def render_rai_metadata():
                 key=key,
                 value=metadata.data_collection_type,
                 on_change=handle_rai_change,
-                args=(RaiEvent.RAI_DATA_COLLECTION_TYPE_OTHERS, metadata, key),
+                args=(RaiEvent.RAI_DATA_COLLECTION_TYPE, metadata, key),
             )
             key = "metadata-data-collection-missing"
             st.text_area(
@@ -137,6 +137,7 @@ def render_rai_metadata():
                                     RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL,
                                     metadata,
                                     key,
+                                    index
                                 ),
                             )
                     else:
@@ -218,7 +219,7 @@ def render_rai_metadata():
                             key=key,
                             value=use_case,
                             on_change=handle_rai_change,
-                            args=(RaiEvent.RAI_DATA_USE_CASES, metadata, key),
+                            args=(RaiEvent.RAI_DATA_USE_CASES, metadata, key, index),
                         )
                 else:
                     metadata.data_use_cases = [metadata.data_use_cases]
@@ -272,7 +273,7 @@ def render_rai_metadata():
                             key=key,
                             value=protocol,
                             on_change=handle_rai_change,
-                            args=(RaiEvent.RAI_DATA_BIAS, metadata, key),
+                            args=(RaiEvent.RAI_DATA_BIAS, metadata, key, index),
                         )
                 else:
                     metadata.data_biases = [metadata.data_biases]
@@ -333,7 +334,7 @@ def render_rai_metadata():
                             key=key,
                             value=protocol,
                             on_change=handle_rai_change,
-                            args=(RaiEvent.RAI_SENSITIVE, metadata, key),
+                            args=(RaiEvent.RAI_SENSITIVE, metadata, key, index),
                         )
                 else:
                     metadata.personal_sensitive_information = [
@@ -399,7 +400,7 @@ def render_rai_metadata():
                             key=key,
                             value=protocol,
                             on_change=handle_rai_change,
-                            args=(RaiEvent.RAI_DATA_LIMITATION, metadata, key),
+                            args=(RaiEvent.RAI_DATA_LIMITATION, metadata, key, index),
                         )
                 else:
                     metadata.data_limitations = [metadata.data_limitations]

--- a/editor/views/rai.py
+++ b/editor/views/rai.py
@@ -29,41 +29,40 @@ def render_rai_metadata():
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_COLLECTION, metadata, key),
             )
-            with st.expander("Data Collection Type", expanded=True):
-                key = "metadata-data-collection-type"
-                st.multiselect(
-                    label=("Define the data collection type."),
-                    options=[
-                        "Surveys",
-                        "Secondary Data analysis",
-                        "Physical data collection",
-                        "Direct measurement",
-                        "Document analysis",
-                        "Manual Human Curator",
-                        "Software Collection",
-                        "Experiments",
-                        "Web Scraping",
-                        "Web API",
-                        "Focus groups",
-                        "Self-reporting",
-                        "Customer feedback data",
-                        "User-generated content data",
-                        "Passive Data Collection",
-                        "Others",
-                    ],
-                    key="metadata-data-collection-type",
-                    default=metadata.data_collection_type,
-                    on_change=handle_rai_change,
-                    args=(RaiEvent.RAI_DATA_COLLECTION_TYPE, metadata, key),
-                )
-                key = "metadata-data-collection-type-others"
-                st.text_area(
-                    label=("**Type**. If others, define the data collection type"),
-                    key="metadata-data-collection-type-others",
-                    value=metadata.data_collection_type,
-                    on_change=handle_rai_change,
-                    args=(RaiEvent.RAI_DATA_COLLECTION_TYPE_OTHERS, metadata, key),
-                )
+            #with st.expander("Data Collection Type", expanded=True):
+            #    key = "metadata-data-collection-type"
+            #    st.multiselect(
+            #        label=("Define the data collection type."),
+            #        options=[
+            #            "Surveys",
+            #            "Secondary Data analysis",
+            #            "Physical data collection",
+            #            "Direct measurement",
+            #            "Document analysis",
+            #            "Manual Human Curator",
+            #            "Software Collection",
+            #            "Experiments",
+            #            "Web Scraping",
+            #            "Web API",
+            #            "Focus groups",
+            #           "Self-reporting",
+            #            "Customer feedback data",
+            #            "User-generated content data",
+            #            "Passive Data Collection",
+            #            "Others",
+            #        ],
+            #        key="metadata-data-collection-type",
+            #        on_change=handle_rai_change,
+            #        args=(RaiEvent.RAI_DATA_COLLECTION_TYPE, metadata, key),
+            #    )
+            key = "metadata-data-collection-type"
+            st.text_area(
+                label=("Define the data collection type. Recommended values Recommended values: Surveys, Secondary Data analysis, Physical data collection, Direct measurement, Document analysis, Manual Human Curator, Software Collection, Experiments, Web Scraping, Web API, Focus groups, Self-reporting, Customer feedback data, User-generated content data, Passive Data Collection, Others"),
+                key="metadata-data-collection-type",
+                value=metadata.data_collection_type,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_COLLECTION_TYPE_OTHERS, metadata, key),
+            )
             key = "metadata-data-collection-missing"
             st.text_area(
                 label=("**Missing Data**. "),
@@ -209,25 +208,25 @@ def render_rai_metadata():
                             metadata.data_preprocessing_protocol.pop()
                             st.rerun()
 
-            key = "metadata-data-preprocessing-manipulation"
+            key = "metadata-data-manipulation-protocol"
             st.text_area(
                 label=(
                     "**Manipulation**. Description of data manipulation process if applicable    "
                 ),
-                key="metadata-data-preprocessing-manipulation",
-                value=metadata.data_preprocessing_manipulation,
+                key=key,
+                value=metadata.data_manipulation_protocol,
                 on_change=handle_rai_change,
-                args=(RaiEvent.RAI_DATA_PREPROCESSING_MANIPULATION, metadata, key),
+                args=(RaiEvent.RAI_DATA_MANIPULATION_PROTOCOL, metadata, key),
             )
-            key = "metadata-data-preprocessing-imputation"
+            key = "metadata-data-imputation-protocol"
             st.text_area(
                 label=(
                     "**Imputation**. Description of data imputation process if applicable  "
                 ),
-                key="metadata-data-preprocessing-imputation",
-                value=metadata.data_preprocessing_imputation,
+                key=key,
+                value=metadata.data_imputation_protocol,
                 on_change=handle_rai_change,
-                args=(RaiEvent.RAI_DATA_PREPROCESSING_IMPUTATION, metadata, key),
+                args=(RaiEvent.RAI_DATA_IMPUTATION_PROTOCOL, metadata, key),
             )
 
     with col2.expander("**Data uses and social impact**", expanded=True):

--- a/editor/views/rai.py
+++ b/editor/views/rai.py
@@ -29,32 +29,6 @@ def render_rai_metadata():
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_COLLECTION, metadata, key),
             )
-            # with st.expander("Data Collection Type", expanded=True):
-            #    key = "metadata-data-collection-type"
-            #    st.multiselect(
-            #        label=("Define the data collection type."),
-            #        options=[
-            #            "Surveys",
-            #            "Secondary Data analysis",
-            #            "Physical data collection",
-            #            "Direct measurement",
-            #            "Document analysis",
-            #            "Manual Human Curator",
-            #            "Software Collection",
-            #            "Experiments",
-            #            "Web Scraping",
-            #            "Web API",
-            #            "Focus groups",
-            #           "Self-reporting",
-            #            "Customer feedback data",
-            #            "User-generated content data",
-            #            "Passive Data Collection",
-            #            "Others",
-            #        ],
-            #        key="metadata-data-collection-type",
-            #        on_change=handle_rai_change,
-            #        args=(RaiEvent.RAI_DATA_COLLECTION_TYPE, metadata, key),
-            #    )
             key = "metadata-data-collection-type"
             st.text_area(
                 label=(

--- a/editor/views/rai.py
+++ b/editor/views/rai.py
@@ -119,13 +119,13 @@ def render_rai_metadata():
                 args=(RaiEvent.RAI_DATA_ANNOTATION_PER_ITEM, metadata, key),
             )
         with st.expander("**Data Preprocessing**", expanded=False):
-            oneToManyProperty(
-                "**Protocols**",
-                metadata,
-                metadata.data_preprocessing_protocol,
-                "metadata-data-preprocessing-protocol_",
-                "Description of data manipulation process if applicable ",
-                RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL,
+            one_to_many_property(
+                title="**Protocols**",
+                metadata=metadata,
+                attributes=metadata.data_preprocessing_protocol,
+                key="metadata-data-preprocessing-protocol_",
+                label="Description of data manipulation process if applicable ",
+                event=RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL,
             )
 
             key = "metadata-data-manipulation-protocol"
@@ -150,34 +150,31 @@ def render_rai_metadata():
             )
 
     with col2.expander("**Data uses and social impact**", expanded=True):
-        # Data use cases
-        oneToManyProperty(
-            "**Use cases**",
-            metadata,
-            metadata.data_use_cases,
-            "metadata-data-use-cases_",
-            "Dataset use case - training, testing, validation, development or production use, fine tuning, others (please specify), usage guidelines, recommended uses, etc.",
-            RaiEvent.RAI_DATA_USE_CASES,
+        one_to_many_property(
+            title="**Use cases**",
+            metadata=metadata,
+            attributes=metadata.data_use_cases,
+            key="metadata-data-use-cases_",
+            label="Dataset use case - training, testing, validation, development or production use, fine tuning, others (please specify), usage guidelines, recommended uses, etc.",
+            event=RaiEvent.RAI_DATA_USE_CASES,
         )
 
-        # Data biases
-        oneToManyProperty(
-            "**Data biases**",
-            metadata,
-            metadata.data_biases,
-            "metadata-data-biases_",
-            "**Data biases**. Involves understanding the potential risks associated  with data usage and to prevent unintended and potentially harmful consequences that may arise from using models trained on or evaluated with the respective data",
-            RaiEvent.RAI_DATA_BIAS,
+        one_to_many_property(
+            title="**Data biases**",
+            metadata= metadata,
+            attributes=metadata.data_biases,
+            key="metadata-data-biases_",
+            label="**Data biases**. Involves understanding the potential risks associated  with data usage and to prevent unintended and potentially harmful consequences that may arise from using models trained on or evaluated with the respective data",
+            event=RaiEvent.RAI_DATA_BIAS,
         )
 
-        # Data sensitive
-        oneToManyProperty(
-            "**Personal and sensitive information**",
-            metadata,
-            metadata.personal_sensitive_information,
-            "metadata-personal-sensitive-information_",
-            "Personal and sensitive information, if contained within the dataset, can play an important role in the mitigation of any risks and the responsible use of the datasets",
-            RaiEvent.RAI_SENSITIVE,
+        one_to_many_property(
+            title="**Personal and sensitive information**",
+            metadata=metadata,
+            attributes=metadata.personal_sensitive_information,
+            key="metadata-personal-sensitive-information_",
+            label="Personal and sensitive information, if contained within the dataset, can play an important role in the mitigation of any risks and the responsible use of the datasets",
+            event=RaiEvent.RAI_SENSITIVE,
         )
 
         key = "metadata-social-impact"
@@ -189,8 +186,7 @@ def render_rai_metadata():
             args=(RaiEvent.RAI_DATA_SOCIAL_IMPACT, metadata, key),
         )
 
-        # Data Limitations
-        oneToManyProperty(
+        one_to_many_property(
             "**Data limitations**",
             metadata,
             metadata.data_limitations,
@@ -211,32 +207,23 @@ def render_rai_metadata():
         )
 
 
-def oneToManyProperty(
-    wrapperTitle: str, metadata: Metadata, attribute, key: str, label: str, event: str
+def one_to_many_property(
+    title: str, metadata: Metadata, attributes, key: str, label: str, event: str
 ):
-    with st.expander(wrapperTitle, expanded=True):
-        if attribute:
-            if isinstance(attribute, list):
-                for index, singleAttribute in enumerate(attribute):
-                    key = key + str(index)
-                    st.text_area(
-                        label=(label),
-                        key=key,
-                        value=singleAttribute,
-                        on_change=handle_rai_change,
-                        args=(event, metadata, key, index),
-                    )
-            else:
-                attribute = [attribute]
-                key = key + "0"
+    """Generates a one to many cardinality property. Attributes should be empty, have one element or being a list of elements"""
+    with st.expander(title, expanded=True):
+        if attributes:
+            if not isinstance(attributes, list):  
+                attributes = [attributes]
+            for index, single_attribute in enumerate(attributes):
+                key = key + str(index)
                 st.text_area(
                     label=(label),
                     key=key,
-                    value=attribute,
+                    value=single_attribute,
                     on_change=handle_rai_change,
-                    args=(event, metadata, key),
+                    args=(event, metadata, key, index),
                 )
-
         else:
             key = key + "0"
             st.text_area(
@@ -248,15 +235,15 @@ def oneToManyProperty(
         add, remove = st.columns(2)
         with add:
             if st.button("+ add", key=key + "add"):
-                if attribute:
-                    attribute.append("")
+                if attributes:
+                    attributes.append("")
                     st.rerun()
                 else:
-                    attribute = []
-                    attribute.append("")
+                    attributes = []
+                    attributes.append("")
                     st.rerun()
         with remove:
             if st.button("- remove", key=key + "remove"):
-                if attribute:
-                    attribute.pop()
+                if attributes:
+                    attributes.pop()
                     st.rerun()

--- a/editor/views/rai.py
+++ b/editor/views/rai.py
@@ -60,7 +60,7 @@ def render_rai_metadata():
                 st.text_area(
                     label=("**Type**. If others, define the data collection type"),
                     key="metadata-data-collection-type-others",
-                    value=metadata.data_collection_type_others,
+                    value=metadata.data_collection_type,
                     on_change=handle_rai_change,
                     args=(RaiEvent.RAI_DATA_COLLECTION_TYPE_OTHERS, metadata, key),
                 )
@@ -69,7 +69,7 @@ def render_rai_metadata():
                 label=("**Missing Data**. "),
                 key="metadata-data-collection-missing",
                 placeholder="Description of missing data in structured/unstructured form",
-                value=metadata.data_collection_missing,
+                value=metadata.data_collection_missing_data,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_COLLECTION_MISSING_DATA, metadata, key),
             )
@@ -78,30 +78,10 @@ def render_rai_metadata():
                 label=("**Raw Data**. "),
                 key="metadata-data-collection-raw",
                 placeholder="Description of the raw data i.e. source of the data ",
-                value=metadata.data_collection_raw,
+                value=metadata.data_collection_raw_data,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_COLLECTION_RAW, metadata, key),
             )
-            with st.expander(
-                "Data collection timeframe in terms of start and end the collection process",
-                expanded=True,
-            ):
-                key = "metadata-data-collection-timeframe-start"
-                st.date_input(
-                    label=("Start: **range** https://schema.org/DateTime "),
-                    key="metadata-data-collection-timeframe-start",
-                    value=metadata.data_collection_timeframe_start,
-                    on_change=handle_rai_change,
-                    args=(RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME_START, metadata, key),
-                )
-                key = "metadata-data-collection-timeframe-end"
-                st.date_input(
-                    label=("End **range**: https://schema.org/DateTime "),
-                    key="metadata-data-collection-timeframe-end",
-                    value=metadata.data_collection_timeframe_end,
-                    on_change=handle_rai_change,
-                    args=(RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME_END, metadata, key),
-                )
         with st.expander("**Data Annotation**", expanded=False):
             key = "metadata-data-annotation-protocol"
             st.text_area(
@@ -139,7 +119,7 @@ def render_rai_metadata():
                     "**Demographics**. List of demographics specifications about the annotators "
                 ),
                 key="metadata-data-annotation-demographics",
-                value=metadata.data_annotation_demographics,
+                value=metadata.annotator_demographics,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_ANNOTATION_DEMOGRAPHICS, metadata, key),
             )
@@ -149,7 +129,7 @@ def render_rai_metadata():
                     "**Tools**. List of software used for data annotation ( e.g. concept extraction, NER, and additional characteristics of the tools used for annotation to allow for replication or extension)  "
                 ),
                 key="metadata-data-annotation-tools",
-                value=metadata.data_annotation_tools,
+                value=metadata.machine_annotation_tools,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_ANNOTATION_TOOLS, metadata, key),
             )
@@ -159,7 +139,7 @@ def render_rai_metadata():
                     "**Annotation per item**. Number of human labels per dataset item  "
                 ),
                 key="metadata-data-annotation-per-item",
-                value=metadata.data_annotation_per_item,
+                value=metadata.annotation_per_item,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_ANNOTATION_PER_ITEM, metadata, key),
             )
@@ -363,9 +343,11 @@ def render_rai_metadata():
                         metadata.data_biases.pop()
                         st.rerun()
         with st.expander("**Personal and sensitive information**", expanded=True):
-            if metadata.data_sensitive:
-                if type(metadata.data_sensitive) is list:
-                    for index, protocol in enumerate(metadata.data_sensitive):
+            if metadata.personal_sensitive_information:
+                if type(metadata.personal_sensitive_information) is list:
+                    for index, protocol in enumerate(
+                        metadata.personal_sensitive_information
+                    ):
                         key = "metadata-personal-sensitive-information_" + str(index)
                         st.text_area(
                             label=(
@@ -379,7 +361,9 @@ def render_rai_metadata():
                             args=(RaiEvent.RAI_SENSITIVE, metadata, key),
                         )
                 else:
-                    metadata.data_sensitive = [metadata.data_sensitive]
+                    metadata.personal_sensitive_information = [
+                        metadata.personal_sensitive_information
+                    ]
                     key = "metadata-personal-sensitive-information_" + "0"
                     st.text_area(
                         label=(
@@ -388,7 +372,7 @@ def render_rai_metadata():
                             " mitigation of any risks and the responsible use of the datasets."
                         ),
                         key=key,
-                        value=metadata.data_sensitive,
+                        value=metadata.personal_sensitive_information,
                         on_change=handle_rai_change,
                         args=(RaiEvent.RAI_SENSITIVE, metadata, key),
                     )
@@ -407,17 +391,17 @@ def render_rai_metadata():
             add, remove = st.columns(2)
             with add:
                 if st.button("+ add sensitive"):
-                    if metadata.data_sensitive:
-                        metadata.data_sensitive.append("")
+                    if metadata.personal_sensitive_information:
+                        metadata.personal_sensitive_information.append("")
                         st.rerun()
                     else:
-                        metadata.data_sensitive = []
-                        metadata.data_sensitive.append("")
+                        metadata.personal_sensitive_information = []
+                        metadata.personal_sensitive_information.append("")
                         st.rerun()
             with remove:
                 if st.button("- remove sensitive"):
-                    if metadata.data_sensitive:
-                        metadata.data_sensitive.pop()
+                    if metadata.personal_sensitive_information:
+                        metadata.personal_sensitive_information.pop()
                         st.rerun()
 
         key = "metadata-social-impact"
@@ -429,9 +413,9 @@ def render_rai_metadata():
             args=(RaiEvent.RAI_DATA_SOCIAL_IMPACT, metadata, key),
         )
         with st.expander("**Data limitations**", expanded=True):
-            if metadata.data_limitation:
-                if type(metadata.data_limitation) is list:
-                    for index, protocol in enumerate(metadata.data_limitation):
+            if metadata.data_limitations:
+                if type(metadata.data_limitations) is list:
+                    for index, protocol in enumerate(metadata.data_limitations):
                         key = "metadata-data-limitations_" + str(index)
                         st.text_area(
                             label=(
@@ -443,14 +427,14 @@ def render_rai_metadata():
                             args=(RaiEvent.RAI_DATA_LIMITATION, metadata, key),
                         )
                 else:
-                    metadata.data_limitation = [metadata.data_limitation]
+                    metadata.data_limitations = [metadata.data_limitations]
                     key = "metadata-data-limitations_" + "0"
                     st.text_area(
                         label=(
                             "Known limitations - Data generalization limits (e.g related to data distribution, data quality issues, or data sources) and on-recommended uses."
                         ),
                         key=key,
-                        value=metadata.data_limitation,
+                        value=metadata.data_limitations,
                         on_change=handle_rai_change,
                         args=(RaiEvent.RAI_DATA_LIMITATION, metadata, key),
                     )
@@ -468,17 +452,17 @@ def render_rai_metadata():
             add, remove = st.columns(2)
             with add:
                 if st.button("+ add limitations"):
-                    if metadata.data_limitation:
-                        metadata.data_limitation.append("")
+                    if metadata.data_limitations:
+                        metadata.data_limitations.append("")
                         st.rerun()
                     else:
-                        metadata.data_limitation = []
-                        metadata.data_limitation.append("")
+                        metadata.data_limitations = []
+                        metadata.data_limitations.append("")
                         st.rerun()
             with remove:
                 if st.button("- remove limitations"):
-                    if metadata.data_limitation:
-                        metadata.data_limitation.pop()
+                    if metadata.data_limitations:
+                        metadata.data_limitations.pop()
                         st.rerun()
         key = "metadata-data-maintenance"
         st.text_area(
@@ -486,7 +470,7 @@ def render_rai_metadata():
                 "**Data release maintenance**. Versioning information in terms of the updating timeframe, the maintainers, and the deprecation policies. "
             ),
             key=key,
-            value=metadata.data_maintenance,
+            value=metadata.data_release_maintenance_plan,
             on_change=handle_rai_change,
             args=(RaiEvent.RAI_MAINTENANCE, metadata, key),
         )

--- a/editor/views/rai.py
+++ b/editor/views/rai.py
@@ -60,15 +60,15 @@ def render_rai_metadata():
                 label=(
                     "Define the data collection type. Recommended values Recommended values: Surveys, Secondary Data analysis, Physical data collection, Direct measurement, Document analysis, Manual Human Curator, Software Collection, Experiments, Web Scraping, Web API, Focus groups, Self-reporting, Customer feedback data, User-generated content data, Passive Data Collection, Others"
                 ),
-                key="metadata-data-collection-type",
+                key=key,
                 value=metadata.data_collection_type,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_COLLECTION_TYPE_OTHERS, metadata, key),
             )
             key = "metadata-data-collection-missing"
             st.text_area(
-                label=("**Missing Data**. "),
-                key="metadata-data-collection-missing",
+                label=("**Missing Data**."),
+                key=key,
                 placeholder="Description of missing data in structured/unstructured form",
                 value=metadata.data_collection_missing_data,
                 on_change=handle_rai_change,
@@ -76,8 +76,8 @@ def render_rai_metadata():
             )
             key = "metadata-data-collection-raw"
             st.text_area(
-                label=("**Raw Data**. "),
-                key="metadata-data-collection-raw",
+                label=("**Raw Data**."),
+                key=key,
                 placeholder="Description of the raw data i.e. source of the data ",
                 value=metadata.data_collection_raw_data,
                 on_change=handle_rai_change,
@@ -87,9 +87,9 @@ def render_rai_metadata():
             key = "metadata-data-annotation-protocol"
             st.text_area(
                 label=(
-                    "**Protocol**. Description of annotations (labels, ratings) produced, including how these were created or authored -  Annotation Workforce Type, Annotation Characteristic(s), Annotation Description(s), Annotation Task(s), Annotation Distribution(s)  "
+                    "**Protocol**. Description of annotations (labels, ratings) produced, including how these were created or authored -  Annotation Workforce Type, Annotation Characteristic(s), Annotation Description(s), Annotation Task(s), Annotation Distribution(s)"
                 ),
-                key="metadata-data-annotation-protocol",
+                key=key,
                 value=metadata.data_annotation_protocol,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_ANNOTATION_PROTOCOL, metadata, key),
@@ -97,9 +97,9 @@ def render_rai_metadata():
             key = "metadata-data-annotation-platform"
             st.text_area(
                 label=(
-                    "**Platform**. Platform, tool, or library used to collect annotations by human annotators "
+                    "**Platform**. Platform, tool, or library used to collect annotations by human annotators"
                 ),
-                key="metadata-data-annotation-platform",
+                key=key,
                 value=metadata.data_annotation_platform,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_ANNOTATION_PLATFORM, metadata, key),
@@ -107,9 +107,9 @@ def render_rai_metadata():
             key = "metadata-data-annotation-analysis"
             st.text_area(
                 label=(
-                    "**Analysis**. Considerations related to the process of converting the “raw” annotations into the labels that are ultimately packaged in a dataset - Uncertainty or disagreement between annotations on each instance as a signal in the dataset, analysis of systematic disagreements between annotators of different socio demographic group,  how the final dataset annotations will relate to individual annotator responses  "
+                    "**Analysis**. Considerations related to the process of converting the “raw” annotations into the labels that are ultimately packaged in a dataset - Uncertainty or disagreement between annotations on each instance as a signal in the dataset, analysis of systematic disagreements between annotators of different socio demographic group,  how the final dataset annotations will relate to individual annotator responses"
                 ),
-                key="metadata-data-annotation-analysis",
+                key=key,
                 value=metadata.data_annotation_analysis,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_ANNOTATION_ANALYSIS, metadata, key),
@@ -117,9 +117,9 @@ def render_rai_metadata():
             key = "metadata-data-annotation-demographics"
             st.text_area(
                 label=(
-                    "**Demographics**. List of demographics specifications about the annotators "
+                    "**Demographics**. List of demographics specifications about the annotators"
                 ),
-                key="metadata-data-annotation-demographics",
+                key=key,
                 value=metadata.annotator_demographics,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_ANNOTATION_DEMOGRAPHICS, metadata, key),
@@ -129,7 +129,7 @@ def render_rai_metadata():
                 label=(
                     "**Tools**. List of software used for data annotation ( e.g. concept extraction, NER, and additional characteristics of the tools used for annotation to allow for replication or extension)  "
                 ),
-                key="metadata-data-annotation-tools",
+                key=key,
                 value=metadata.machine_annotation_tools,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_ANNOTATION_TOOLS, metadata, key),
@@ -139,7 +139,7 @@ def render_rai_metadata():
                 label=(
                     "**Annotation per item**. Number of human labels per dataset item  "
                 ),
-                key="metadata-data-annotation-per-item",
+                key=key,
                 value=metadata.annotation_per_item,
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_ANNOTATION_PER_ITEM, metadata, key),
@@ -147,7 +147,7 @@ def render_rai_metadata():
         with st.expander("**Data Preprocessing**", expanded=False):
             with st.expander("Protocols", expanded=True):
                 if metadata.data_preprocessing_protocol:
-                    if type(metadata.data_preprocessing_protocol) is list:
+                    if isinstance(metadata.data_preprocessing_protocol, list):
                         for index, protocol in enumerate(
                             metadata.data_preprocessing_protocol
                         ):
@@ -234,15 +234,15 @@ def render_rai_metadata():
     with col2.expander("**Data uses and social impact**", expanded=True):
         with st.expander("**Use cases**", expanded=True):
             if metadata.data_use_cases:
-                if type(metadata.data_use_cases) is list:
-                    for index, protocol in enumerate(metadata.data_use_cases):
+                if isinstance(metadata.data_use_cases,list) :
+                    for index, use_case in enumerate(metadata.data_use_cases):
                         key = "metadata-data-use-cases_" + str(index)
                         st.text_area(
                             label=(
                                 "Dataset use case - training, testing, validation, development or production use, fine tuning, others (please specify), usage guidelines, recommended uses, etc."
                             ),
                             key=key,
-                            value=protocol,
+                            value=use_case,
                             on_change=handle_rai_change,
                             args=(RaiEvent.RAI_DATA_USE_CASES, metadata, key),
                         )
@@ -285,7 +285,7 @@ def render_rai_metadata():
                         st.rerun()
         with st.expander("**Data biases**", expanded=True):
             if metadata.data_biases:
-                if type(metadata.data_biases) is list:
+                if isinstance(metadata.data_biases, list):
                     for index, protocol in enumerate(metadata.data_biases):
                         key = "metadata-data-biases_" + str(index)
                         st.text_area(
@@ -345,7 +345,7 @@ def render_rai_metadata():
                         st.rerun()
         with st.expander("**Personal and sensitive information**", expanded=True):
             if metadata.personal_sensitive_information:
-                if type(metadata.personal_sensitive_information) is list:
+                if isinstance(metadata.personal_sensitive_information, list):
                     for index, protocol in enumerate(
                         metadata.personal_sensitive_information
                     ):
@@ -415,7 +415,7 @@ def render_rai_metadata():
         )
         with st.expander("**Data limitations**", expanded=True):
             if metadata.data_limitations:
-                if type(metadata.data_limitations) is list:
+                if isinstance(metadata.data_limitations, list):
                     for index, protocol in enumerate(metadata.data_limitations):
                         key = "metadata-data-limitations_" + str(index)
                         st.text_area(

--- a/editor/views/rai.py
+++ b/editor/views/rai.py
@@ -119,71 +119,14 @@ def render_rai_metadata():
                 args=(RaiEvent.RAI_DATA_ANNOTATION_PER_ITEM, metadata, key),
             )
         with st.expander("**Data Preprocessing**", expanded=False):
-            with st.expander("Protocols", expanded=True):
-                if metadata.data_preprocessing_protocol:
-                    if isinstance(metadata.data_preprocessing_protocol, list):
-                        for index, protocol in enumerate(
-                            metadata.data_preprocessing_protocol
-                        ):
-                            key = "metadata-data-preprocessing-protocol_" + str(index)
-                            st.text_area(
-                                label=(
-                                    "Description of data manipulation process if applicable   "
-                                ),
-                                key=key,
-                                value=protocol,
-                                on_change=handle_rai_change,
-                                args=(
-                                    RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL,
-                                    metadata,
-                                    key,
-                                    index
-                                ),
-                            )
-                    else:
-                        metadata.data_preprocessing_protocol = [
-                            metadata.data_preprocessing_protocol
-                        ]
-                        key = "metadata-data-preprocessing-protocol_" + "0"
-                        st.text_area(
-                            label=(
-                                "Description of data manipulation process if applicable   "
-                            ),
-                            key=key,
-                            value=metadata.data_preprocessing_protocol,
-                            on_change=handle_rai_change,
-                            args=(
-                                RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL,
-                                metadata,
-                                key,
-                            ),
-                        )
-
-                else:
-                    key = "metadata-data-preprocessing-protocol_" + "0"
-                    st.text_area(
-                        label=(
-                            "Description of data manipulation process if applicable   "
-                        ),
-                        key=key,
-                        on_change=handle_rai_change,
-                        args=(RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL, metadata, key),
-                    )
-                add, remove = st.columns(2)
-                with add:
-                    if st.button("+ add protocol"):
-                        if metadata.data_preprocessing_protocol:
-                            metadata.data_preprocessing_protocol.append("")
-                            st.rerun()
-                        else:
-                            metadata.data_preprocessing_protocol = []
-                            metadata.data_preprocessing_protocol.append("")
-                            st.rerun()
-                with remove:
-                    if st.button("- remove protocol"):
-                        if metadata.data_preprocessing_protocol:
-                            metadata.data_preprocessing_protocol.pop()
-                            st.rerun()
+            oneToManyProperty(
+                "**Protocols**",
+                metadata,
+                metadata.data_preprocessing_protocol,
+                "metadata-data-preprocessing-protocol_",
+                "Description of data manipulation process if applicable ",
+                RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL,
+            )
 
             key = "metadata-data-manipulation-protocol"
             st.text_area(
@@ -207,178 +150,35 @@ def render_rai_metadata():
             )
 
     with col2.expander("**Data uses and social impact**", expanded=True):
-        with st.expander("**Use cases**", expanded=True):
-            if metadata.data_use_cases:
-                if isinstance(metadata.data_use_cases, list):
-                    for index, use_case in enumerate(metadata.data_use_cases):
-                        key = "metadata-data-use-cases_" + str(index)
-                        st.text_area(
-                            label=(
-                                "Dataset use case - training, testing, validation, development or production use, fine tuning, others (please specify), usage guidelines, recommended uses, etc."
-                            ),
-                            key=key,
-                            value=use_case,
-                            on_change=handle_rai_change,
-                            args=(RaiEvent.RAI_DATA_USE_CASES, metadata, key, index),
-                        )
-                else:
-                    metadata.data_use_cases = [metadata.data_use_cases]
-                    key = "metadata-data-use-cases_" + "0"
-                    st.text_area(
-                        label=(
-                            "Dataset use case - training, testing, validation, development or production use, fine tuning, others (please specify), usage guidelines, recommended uses, etc."
-                        ),
-                        key=key,
-                        value=metadata.data_use_cases,
-                        on_change=handle_rai_change,
-                        args=(RaiEvent.RAI_DATA_USE_CASES, metadata, key),
-                    )
-            else:
-                key = "metadata-data-use-cases_" + "0"
-                st.text_area(
-                    label=(
-                        "Dataset use case - training, testing, validation, development or production use, fine tuning, others (please specify), usage guidelines, recommended uses, etc."
-                    ),
-                    key=key,
-                    on_change=handle_rai_change,
-                    args=(RaiEvent.RAI_DATA_USE_CASES, metadata, key),
-                )
-            add, remove = st.columns(2)
-            with add:
-                if st.button("+ add use case"):
-                    if metadata.data_use_cases:
-                        metadata.data_use_cases.append("")
-                        st.rerun()
-                    else:
-                        metadata.data_use_cases = []
-                        metadata.data_use_cases.append("")
-                        st.rerun()
-            with remove:
-                if st.button("- remove use case"):
-                    if metadata.data_use_cases:
-                        metadata.data_use_cases.pop()
-                        st.rerun()
-        with st.expander("**Data biases**", expanded=True):
-            if metadata.data_biases:
-                if isinstance(metadata.data_biases, list):
-                    for index, protocol in enumerate(metadata.data_biases):
-                        key = "metadata-data-biases_" + str(index)
-                        st.text_area(
-                            label=(
-                                "**Data biases**. Involves understanding the potential risks associated"
-                                " with data usage and to prevent unintended and potentially harmful"
-                                " consequences that may arise from using models trained on or evaluated"
-                                " with the respective data."
-                            ),
-                            key=key,
-                            value=protocol,
-                            on_change=handle_rai_change,
-                            args=(RaiEvent.RAI_DATA_BIAS, metadata, key, index),
-                        )
-                else:
-                    metadata.data_biases = [metadata.data_biases]
-                    key = "metadata-data-biases_" + "0"
-                    st.text_area(
-                        label=(
-                            "**Data biases**. Involves understanding the potential risks associated"
-                            " with data usage and to prevent unintended and potentially harmful"
-                            " consequences that may arise from using models trained on or evaluated"
-                            " with the respective data."
-                        ),
-                        key=key,
-                        value=metadata.data_biases,
-                        on_change=handle_rai_change,
-                        args=(RaiEvent.RAI_DATA_BIAS, metadata, key),
-                    )
-            else:
-                key = "metadata-data-biases_" + "0"
-                st.text_area(
-                    label=(
-                        "Involves understanding the potential risks associated"
-                        " with data usage and to prevent unintended and potentially harmful"
-                        " consequences that may arise from using models trained on or evaluated"
-                        " with the respective data."
-                    ),
-                    key=key,
-                    on_change=handle_rai_change,
-                    args=(RaiEvent.RAI_DATA_BIAS, metadata, key),
-                )
-            add, remove = st.columns(2)
-            with add:
-                if st.button("+ add bias"):
-                    if metadata.data_biases:
-                        metadata.data_biases.append("")
-                        st.rerun()
-                    else:
-                        metadata.data_biases = []
-                        metadata.data_biases.append("")
-                        st.rerun()
-            with remove:
-                if st.button("- remove bias"):
-                    if metadata.data_biases:
-                        metadata.data_biases.pop()
-                        st.rerun()
-        with st.expander("**Personal and sensitive information**", expanded=True):
-            if metadata.personal_sensitive_information:
-                if isinstance(metadata.personal_sensitive_information, list):
-                    for index, protocol in enumerate(
-                        metadata.personal_sensitive_information
-                    ):
-                        key = "metadata-personal-sensitive-information_" + str(index)
-                        st.text_area(
-                            label=(
-                                "Personal and sensitive information, if"
-                                " contained within the dataset, can play an important role in the"
-                                " mitigation of any risks and the responsible use of the datasets."
-                            ),
-                            key=key,
-                            value=protocol,
-                            on_change=handle_rai_change,
-                            args=(RaiEvent.RAI_SENSITIVE, metadata, key, index),
-                        )
-                else:
-                    metadata.personal_sensitive_information = [
-                        metadata.personal_sensitive_information
-                    ]
-                    key = "metadata-personal-sensitive-information_" + "0"
-                    st.text_area(
-                        label=(
-                            "Personal and sensitive information, if"
-                            " contained within the dataset, can play an important role in the"
-                            " mitigation of any risks and the responsible use of the datasets."
-                        ),
-                        key=key,
-                        value=metadata.personal_sensitive_information,
-                        on_change=handle_rai_change,
-                        args=(RaiEvent.RAI_SENSITIVE, metadata, key),
-                    )
-            else:
-                key = "metadata-personal-sensitive-information_" + "0"
-                st.text_area(
-                    label=(
-                        "if"
-                        " contained within the dataset, can play an important role in the"
-                        " mitigation of any risks and the responsible use of the datasets."
-                    ),
-                    key=key,
-                    on_change=handle_rai_change,
-                    args=(RaiEvent.RAI_SENSITIVE, metadata, key),
-                )
-            add, remove = st.columns(2)
-            with add:
-                if st.button("+ add sensitive"):
-                    if metadata.personal_sensitive_information:
-                        metadata.personal_sensitive_information.append("")
-                        st.rerun()
-                    else:
-                        metadata.personal_sensitive_information = []
-                        metadata.personal_sensitive_information.append("")
-                        st.rerun()
-            with remove:
-                if st.button("- remove sensitive"):
-                    if metadata.personal_sensitive_information:
-                        metadata.personal_sensitive_information.pop()
-                        st.rerun()
+        # Data use cases
+        oneToManyProperty(
+            "**Use cases**",
+            metadata,
+            metadata.data_use_cases,
+            "metadata-data-use-cases_",
+            "Dataset use case - training, testing, validation, development or production use, fine tuning, others (please specify), usage guidelines, recommended uses, etc.",
+            RaiEvent.RAI_DATA_USE_CASES,
+        )
+
+        # Data biases
+        oneToManyProperty(
+            "**Data biases**",
+            metadata,
+            metadata.data_biases,
+            "metadata-data-biases_",
+            "**Data biases**. Involves understanding the potential risks associated  with data usage and to prevent unintended and potentially harmful consequences that may arise from using models trained on or evaluated with the respective data",
+            RaiEvent.RAI_DATA_BIAS,
+        )
+
+        # Data sensitive
+        oneToManyProperty(
+            "**Personal and sensitive information**",
+            metadata,
+            metadata.personal_sensitive_information,
+            "metadata-personal-sensitive-information_",
+            "Personal and sensitive information, if contained within the dataset, can play an important role in the mitigation of any risks and the responsible use of the datasets",
+            RaiEvent.RAI_SENSITIVE,
+        )
 
         key = "metadata-social-impact"
         st.text_area(
@@ -388,58 +188,17 @@ def render_rai_metadata():
             on_change=handle_rai_change,
             args=(RaiEvent.RAI_DATA_SOCIAL_IMPACT, metadata, key),
         )
-        with st.expander("**Data limitations**", expanded=True):
-            if metadata.data_limitations:
-                if isinstance(metadata.data_limitations, list):
-                    for index, protocol in enumerate(metadata.data_limitations):
-                        key = "metadata-data-limitations_" + str(index)
-                        st.text_area(
-                            label=(
-                                "Known limitations - Data generalization limits (e.g related to data distribution, data quality issues, or data sources) and on-recommended uses."
-                            ),
-                            key=key,
-                            value=protocol,
-                            on_change=handle_rai_change,
-                            args=(RaiEvent.RAI_DATA_LIMITATION, metadata, key, index),
-                        )
-                else:
-                    metadata.data_limitations = [metadata.data_limitations]
-                    key = "metadata-data-limitations_" + "0"
-                    st.text_area(
-                        label=(
-                            "Known limitations - Data generalization limits (e.g related to data distribution, data quality issues, or data sources) and on-recommended uses."
-                        ),
-                        key=key,
-                        value=metadata.data_limitations,
-                        on_change=handle_rai_change,
-                        args=(RaiEvent.RAI_DATA_LIMITATION, metadata, key),
-                    )
 
-            else:
-                key = "metadata-data-limitations_" + "0"
-                st.text_area(
-                    label=(
-                        "Known limitations - Data generalization limits (e.g related to data distribution, data quality issues, or data sources) and on-recommended uses."
-                    ),
-                    key=key,
-                    on_change=handle_rai_change,
-                    args=(RaiEvent.RAI_DATA_LIMITATION, metadata, key),
-                )
-            add, remove = st.columns(2)
-            with add:
-                if st.button("+ add limitations"):
-                    if metadata.data_limitations:
-                        metadata.data_limitations.append("")
-                        st.rerun()
-                    else:
-                        metadata.data_limitations = []
-                        metadata.data_limitations.append("")
-                        st.rerun()
-            with remove:
-                if st.button("- remove limitations"):
-                    if metadata.data_limitations:
-                        metadata.data_limitations.pop()
-                        st.rerun()
+        # Data Limitations
+        oneToManyProperty(
+            "**Data limitations**",
+            metadata,
+            metadata.data_limitations,
+            "metadata-data-limitations_",
+            "Known limitations - Data generalization limits (e.g related to data distribution, data quality issues, or data sources) and on-recommended uses.",
+            RaiEvent.RAI_DATA_LIMITATION,
+        )
+
         key = "metadata-data-maintenance"
         st.text_area(
             label=(
@@ -450,3 +209,54 @@ def render_rai_metadata():
             on_change=handle_rai_change,
             args=(RaiEvent.RAI_MAINTENANCE, metadata, key),
         )
+
+
+def oneToManyProperty(
+    wrapperTitle: str, metadata: Metadata, attribute, key: str, label: str, event: str
+):
+    with st.expander(wrapperTitle, expanded=True):
+        if attribute:
+            if isinstance(attribute, list):
+                for index, singleAttribute in enumerate(attribute):
+                    key = key + str(index)
+                    st.text_area(
+                        label=(label),
+                        key=key,
+                        value=singleAttribute,
+                        on_change=handle_rai_change,
+                        args=(event, metadata, key, index),
+                    )
+            else:
+                attribute = [attribute]
+                key = key + "0"
+                st.text_area(
+                    label=(label),
+                    key=key,
+                    value=attribute,
+                    on_change=handle_rai_change,
+                    args=(event, metadata, key),
+                )
+
+        else:
+            key = key + "0"
+            st.text_area(
+                label=(label),
+                key=key,
+                on_change=handle_rai_change,
+                args=(event, metadata, key),
+            )
+        add, remove = st.columns(2)
+        with add:
+            if st.button("+ add", key=key + "add"):
+                if attribute:
+                    attribute.append("")
+                    st.rerun()
+                else:
+                    attribute = []
+                    attribute.append("")
+                    st.rerun()
+        with remove:
+            if st.button("- remove", key=key + "remove"):
+                if attribute:
+                    attribute.pop()
+                    st.rerun()

--- a/editor/views/rai.py
+++ b/editor/views/rai.py
@@ -234,7 +234,7 @@ def render_rai_metadata():
     with col2.expander("**Data uses and social impact**", expanded=True):
         with st.expander("**Use cases**", expanded=True):
             if metadata.data_use_cases:
-                if isinstance(metadata.data_use_cases,list) :
+                if isinstance(metadata.data_use_cases, list):
                     for index, use_case in enumerate(metadata.data_use_cases):
                         key = "metadata-data-use-cases_" + str(index)
                         st.text_area(

--- a/editor/views/rai.py
+++ b/editor/views/rai.py
@@ -29,7 +29,7 @@ def render_rai_metadata():
                 on_change=handle_rai_change,
                 args=(RaiEvent.RAI_DATA_COLLECTION, metadata, key),
             )
-            #with st.expander("Data Collection Type", expanded=True):
+            # with st.expander("Data Collection Type", expanded=True):
             #    key = "metadata-data-collection-type"
             #    st.multiselect(
             #        label=("Define the data collection type."),
@@ -57,7 +57,9 @@ def render_rai_metadata():
             #    )
             key = "metadata-data-collection-type"
             st.text_area(
-                label=("Define the data collection type. Recommended values Recommended values: Surveys, Secondary Data analysis, Physical data collection, Direct measurement, Document analysis, Manual Human Curator, Software Collection, Experiments, Web Scraping, Web API, Focus groups, Self-reporting, Customer feedback data, User-generated content data, Passive Data Collection, Others"),
+                label=(
+                    "Define the data collection type. Recommended values Recommended values: Surveys, Secondary Data analysis, Physical data collection, Direct measurement, Document analysis, Manual Human Curator, Software Collection, Experiments, Web Scraping, Web API, Focus groups, Self-reporting, Customer feedback data, User-generated content data, Passive Data Collection, Others"
+                ),
                 key="metadata-data-collection-type",
                 value=metadata.data_collection_type,
                 on_change=handle_rai_change,

--- a/editor/views/rai.py
+++ b/editor/views/rai.py
@@ -161,7 +161,7 @@ def render_rai_metadata():
 
         one_to_many_property(
             title="**Data biases**",
-            metadata= metadata,
+            metadata=metadata,
             attributes=metadata.data_biases,
             key="metadata-data-biases_",
             label="**Data biases**. Involves understanding the potential risks associated  with data usage and to prevent unintended and potentially harmful consequences that may arise from using models trained on or evaluated with the respective data",
@@ -213,7 +213,7 @@ def one_to_many_property(
     """Generates a one to many cardinality property. Attributes should be empty, have one element or being a list of elements"""
     with st.expander(title, expanded=True):
         if attributes:
-            if not isinstance(attributes, list):  
+            if not isinstance(attributes, list):
                 attributes = [attributes]
             for index, single_attribute in enumerate(attributes):
                 key = key + str(index)

--- a/editor/views/rai.py
+++ b/editor/views/rai.py
@@ -1,0 +1,492 @@
+import streamlit as st
+
+from core.state import Metadata
+from events.metadata import find_license_index
+from events.metadata import LICENSES
+from events.metadata import LICENSES_URL
+from events.rai import handle_rai_change
+from events.rai import RaiEvent
+
+_INFO_TEXT = """This tab is the Responsible AI extension of Croissant. **Filling this tab is optional.**
+        
+More information on how to fill this part at: http://mlcommons.org/croissant/RAI/
+"""
+
+
+def render_rai_metadata():
+    """Renders the `Metadata` view."""
+    metadata: Metadata = st.session_state[Metadata]
+    st.info(_INFO_TEXT, icon="💡")
+    col1, col2 = st.columns([1, 1])
+    with col1.expander("**Provenance**", expanded=True):
+        with st.expander("**Data Collection**", expanded=False):
+            key = "metadata-data-collection"
+            st.text_area(
+                label=("Explanation"),
+                placeholder="Explain the key stages of the data collection process to improves understanding of potential users",
+                key=key,
+                value=metadata.data_collection,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_COLLECTION, metadata, key),
+            )
+            with st.expander("Data Collection Type", expanded=True):
+                key = "metadata-data-collection-type"
+                st.multiselect(
+                    label=("Define the data collection type."),
+                    options=[
+                        "Surveys",
+                        "Secondary Data analysis",
+                        "Physical data collection",
+                        "Direct measurement",
+                        "Document analysis",
+                        "Manual Human Curator",
+                        "Software Collection",
+                        "Experiments",
+                        "Web Scraping",
+                        "Web API",
+                        "Focus groups",
+                        "Self-reporting",
+                        "Customer feedback data",
+                        "User-generated content data",
+                        "Passive Data Collection",
+                        "Others",
+                    ],
+                    key="metadata-data-collection-type",
+                    default=metadata.data_collection_type,
+                    on_change=handle_rai_change,
+                    args=(RaiEvent.RAI_DATA_COLLECTION_TYPE, metadata, key),
+                )
+                key = "metadata-data-collection-type-others"
+                st.text_area(
+                    label=("**Type**. If others, define the data collection type"),
+                    key="metadata-data-collection-type-others",
+                    value=metadata.data_collection_type_others,
+                    on_change=handle_rai_change,
+                    args=(RaiEvent.RAI_DATA_COLLECTION_TYPE_OTHERS, metadata, key),
+                )
+            key = "metadata-data-collection-missing"
+            st.text_area(
+                label=("**Missing Data**. "),
+                key="metadata-data-collection-missing",
+                placeholder="Description of missing data in structured/unstructured form",
+                value=metadata.data_collection_missing,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_COLLECTION_MISSING_DATA, metadata, key),
+            )
+            key = "metadata-data-collection-raw"
+            st.text_area(
+                label=("**Raw Data**. "),
+                key="metadata-data-collection-raw",
+                placeholder="Description of the raw data i.e. source of the data ",
+                value=metadata.data_collection_raw,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_COLLECTION_RAW, metadata, key),
+            )
+            with st.expander(
+                "Data collection timeframe in terms of start and end the collection process",
+                expanded=True,
+            ):
+                key = "metadata-data-collection-timeframe-start"
+                st.date_input(
+                    label=("Start: **range** https://schema.org/DateTime "),
+                    key="metadata-data-collection-timeframe-start",
+                    value=metadata.data_collection_timeframe_start,
+                    on_change=handle_rai_change,
+                    args=(RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME_START, metadata, key),
+                )
+                key = "metadata-data-collection-timeframe-end"
+                st.date_input(
+                    label=("End **range**: https://schema.org/DateTime "),
+                    key="metadata-data-collection-timeframe-end",
+                    value=metadata.data_collection_timeframe_end,
+                    on_change=handle_rai_change,
+                    args=(RaiEvent.RAI_DATA_COLLECTION_TIMEFRAME_END, metadata, key),
+                )
+        with st.expander("**Data Annotation**", expanded=False):
+            key = "metadata-data-annotation-protocol"
+            st.text_area(
+                label=(
+                    "**Protocol**. Description of annotations (labels, ratings) produced, including how these were created or authored -  Annotation Workforce Type, Annotation Characteristic(s), Annotation Description(s), Annotation Task(s), Annotation Distribution(s)  "
+                ),
+                key="metadata-data-annotation-protocol",
+                value=metadata.data_annotation_protocol,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_ANNOTATION_PROTOCOL, metadata, key),
+            )
+            key = "metadata-data-annotation-platform"
+            st.text_area(
+                label=(
+                    "**Platform**. Platform, tool, or library used to collect annotations by human annotators "
+                ),
+                key="metadata-data-annotation-platform",
+                value=metadata.data_annotation_platform,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_ANNOTATION_PLATFORM, metadata, key),
+            )
+            key = "metadata-data-annotation-analysis"
+            st.text_area(
+                label=(
+                    "**Analysis**. Considerations related to the process of converting the “raw” annotations into the labels that are ultimately packaged in a dataset - Uncertainty or disagreement between annotations on each instance as a signal in the dataset, analysis of systematic disagreements between annotators of different socio demographic group,  how the final dataset annotations will relate to individual annotator responses  "
+                ),
+                key="metadata-data-annotation-analysis",
+                value=metadata.data_annotation_analysis,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_ANNOTATION_ANALYSIS, metadata, key),
+            )
+            key = "metadata-data-annotation-demographics"
+            st.text_area(
+                label=(
+                    "**Demographics**. List of demographics specifications about the annotators "
+                ),
+                key="metadata-data-annotation-demographics",
+                value=metadata.data_annotation_demographics,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_ANNOTATION_DEMOGRAPHICS, metadata, key),
+            )
+            key = "metadata-data-annotation-tools"
+            st.text_area(
+                label=(
+                    "**Tools**. List of software used for data annotation ( e.g. concept extraction, NER, and additional characteristics of the tools used for annotation to allow for replication or extension)  "
+                ),
+                key="metadata-data-annotation-tools",
+                value=metadata.data_annotation_tools,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_ANNOTATION_TOOLS, metadata, key),
+            )
+            key = "metadata-data-annotation-per-item"
+            st.text_area(
+                label=(
+                    "**Annotation per item**. Number of human labels per dataset item  "
+                ),
+                key="metadata-data-annotation-per-item",
+                value=metadata.data_annotation_per_item,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_ANNOTATION_PER_ITEM, metadata, key),
+            )
+        with st.expander("**Data Preprocessing**", expanded=False):
+            with st.expander("Protocols", expanded=True):
+                if metadata.data_preprocessing_protocol:
+                    if type(metadata.data_preprocessing_protocol) is list:
+                        for index, protocol in enumerate(
+                            metadata.data_preprocessing_protocol
+                        ):
+                            key = "metadata-data-preprocessing-protocol_" + str(index)
+                            st.text_area(
+                                label=(
+                                    "Description of data manipulation process if applicable   "
+                                ),
+                                key=key,
+                                value=protocol,
+                                on_change=handle_rai_change,
+                                args=(
+                                    RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL,
+                                    metadata,
+                                    key,
+                                ),
+                            )
+                    else:
+                        metadata.data_preprocessing_protocol = [
+                            metadata.data_preprocessing_protocol
+                        ]
+                        key = "metadata-data-preprocessing-protocol_" + "0"
+                        st.text_area(
+                            label=(
+                                "Description of data manipulation process if applicable   "
+                            ),
+                            key=key,
+                            value=metadata.data_preprocessing_protocol,
+                            on_change=handle_rai_change,
+                            args=(
+                                RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL,
+                                metadata,
+                                key,
+                            ),
+                        )
+
+                else:
+                    key = "metadata-data-preprocessing-protocol_" + "0"
+                    st.text_area(
+                        label=(
+                            "Description of data manipulation process if applicable   "
+                        ),
+                        key=key,
+                        on_change=handle_rai_change,
+                        args=(RaiEvent.RAI_DATA_PREPROCESSING_PROTOCOL, metadata, key),
+                    )
+                add, remove = st.columns(2)
+                with add:
+                    if st.button("+ add protocol"):
+                        if metadata.data_preprocessing_protocol:
+                            metadata.data_preprocessing_protocol.append("")
+                            st.rerun()
+                        else:
+                            metadata.data_preprocessing_protocol = []
+                            metadata.data_preprocessing_protocol.append("")
+                            st.rerun()
+                with remove:
+                    if st.button("- remove protocol"):
+                        if metadata.data_preprocessing_protocol:
+                            metadata.data_preprocessing_protocol.pop()
+                            st.rerun()
+
+            key = "metadata-data-preprocessing-manipulation"
+            st.text_area(
+                label=(
+                    "**Manipulation**. Description of data manipulation process if applicable    "
+                ),
+                key="metadata-data-preprocessing-manipulation",
+                value=metadata.data_preprocessing_manipulation,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_PREPROCESSING_MANIPULATION, metadata, key),
+            )
+            key = "metadata-data-preprocessing-imputation"
+            st.text_area(
+                label=(
+                    "**Imputation**. Description of data imputation process if applicable  "
+                ),
+                key="metadata-data-preprocessing-imputation",
+                value=metadata.data_preprocessing_imputation,
+                on_change=handle_rai_change,
+                args=(RaiEvent.RAI_DATA_PREPROCESSING_IMPUTATION, metadata, key),
+            )
+
+    with col2.expander("**Data uses and social impact**", expanded=True):
+        with st.expander("**Use cases**", expanded=True):
+            if metadata.data_use_cases:
+                if type(metadata.data_use_cases) is list:
+                    for index, protocol in enumerate(metadata.data_use_cases):
+                        key = "metadata-data-use-cases_" + str(index)
+                        st.text_area(
+                            label=(
+                                "Dataset use case - training, testing, validation, development or production use, fine tuning, others (please specify), usage guidelines, recommended uses, etc."
+                            ),
+                            key=key,
+                            value=protocol,
+                            on_change=handle_rai_change,
+                            args=(RaiEvent.RAI_DATA_USE_CASES, metadata, key),
+                        )
+                else:
+                    metadata.data_use_cases = [metadata.data_use_cases]
+                    key = "metadata-data-use-cases_" + "0"
+                    st.text_area(
+                        label=(
+                            "Dataset use case - training, testing, validation, development or production use, fine tuning, others (please specify), usage guidelines, recommended uses, etc."
+                        ),
+                        key=key,
+                        value=metadata.data_use_cases,
+                        on_change=handle_rai_change,
+                        args=(RaiEvent.RAI_DATA_USE_CASES, metadata, key),
+                    )
+            else:
+                key = "metadata-data-use-cases_" + "0"
+                st.text_area(
+                    label=(
+                        "Dataset use case - training, testing, validation, development or production use, fine tuning, others (please specify), usage guidelines, recommended uses, etc."
+                    ),
+                    key=key,
+                    on_change=handle_rai_change,
+                    args=(RaiEvent.RAI_DATA_USE_CASES, metadata, key),
+                )
+            add, remove = st.columns(2)
+            with add:
+                if st.button("+ add use case"):
+                    if metadata.data_use_cases:
+                        metadata.data_use_cases.append("")
+                        st.rerun()
+                    else:
+                        metadata.data_use_cases = []
+                        metadata.data_use_cases.append("")
+                        st.rerun()
+            with remove:
+                if st.button("- remove use case"):
+                    if metadata.data_use_cases:
+                        metadata.data_use_cases.pop()
+                        st.rerun()
+        with st.expander("**Data biases**", expanded=True):
+            if metadata.data_biases:
+                if type(metadata.data_biases) is list:
+                    for index, protocol in enumerate(metadata.data_biases):
+                        key = "metadata-data-biases_" + str(index)
+                        st.text_area(
+                            label=(
+                                "**Data biases**. Involves understanding the potential risks associated"
+                                " with data usage and to prevent unintended and potentially harmful"
+                                " consequences that may arise from using models trained on or evaluated"
+                                " with the respective data."
+                            ),
+                            key=key,
+                            value=protocol,
+                            on_change=handle_rai_change,
+                            args=(RaiEvent.RAI_DATA_BIAS, metadata, key),
+                        )
+                else:
+                    metadata.data_biases = [metadata.data_biases]
+                    key = "metadata-data-biases_" + "0"
+                    st.text_area(
+                        label=(
+                            "**Data biases**. Involves understanding the potential risks associated"
+                            " with data usage and to prevent unintended and potentially harmful"
+                            " consequences that may arise from using models trained on or evaluated"
+                            " with the respective data."
+                        ),
+                        key=key,
+                        value=metadata.data_biases,
+                        on_change=handle_rai_change,
+                        args=(RaiEvent.RAI_DATA_BIAS, metadata, key),
+                    )
+            else:
+                key = "metadata-data-biases_" + "0"
+                st.text_area(
+                    label=(
+                        "Involves understanding the potential risks associated"
+                        " with data usage and to prevent unintended and potentially harmful"
+                        " consequences that may arise from using models trained on or evaluated"
+                        " with the respective data."
+                    ),
+                    key=key,
+                    on_change=handle_rai_change,
+                    args=(RaiEvent.RAI_DATA_BIAS, metadata, key),
+                )
+            add, remove = st.columns(2)
+            with add:
+                if st.button("+ add bias"):
+                    if metadata.data_biases:
+                        metadata.data_biases.append("")
+                        st.rerun()
+                    else:
+                        metadata.data_biases = []
+                        metadata.data_biases.append("")
+                        st.rerun()
+            with remove:
+                if st.button("- remove bias"):
+                    if metadata.data_biases:
+                        metadata.data_biases.pop()
+                        st.rerun()
+        with st.expander("**Personal and sensitive information**", expanded=True):
+            if metadata.data_sensitive:
+                if type(metadata.data_sensitive) is list:
+                    for index, protocol in enumerate(metadata.data_sensitive):
+                        key = "metadata-personal-sensitive-information_" + str(index)
+                        st.text_area(
+                            label=(
+                                "Personal and sensitive information, if"
+                                " contained within the dataset, can play an important role in the"
+                                " mitigation of any risks and the responsible use of the datasets."
+                            ),
+                            key=key,
+                            value=protocol,
+                            on_change=handle_rai_change,
+                            args=(RaiEvent.RAI_SENSITIVE, metadata, key),
+                        )
+                else:
+                    metadata.data_sensitive = [metadata.data_sensitive]
+                    key = "metadata-personal-sensitive-information_" + "0"
+                    st.text_area(
+                        label=(
+                            "Personal and sensitive information, if"
+                            " contained within the dataset, can play an important role in the"
+                            " mitigation of any risks and the responsible use of the datasets."
+                        ),
+                        key=key,
+                        value=metadata.data_sensitive,
+                        on_change=handle_rai_change,
+                        args=(RaiEvent.RAI_SENSITIVE, metadata, key),
+                    )
+            else:
+                key = "metadata-personal-sensitive-information_" + "0"
+                st.text_area(
+                    label=(
+                        "if"
+                        " contained within the dataset, can play an important role in the"
+                        " mitigation of any risks and the responsible use of the datasets."
+                    ),
+                    key=key,
+                    on_change=handle_rai_change,
+                    args=(RaiEvent.RAI_SENSITIVE, metadata, key),
+                )
+            add, remove = st.columns(2)
+            with add:
+                if st.button("+ add sensitive"):
+                    if metadata.data_sensitive:
+                        metadata.data_sensitive.append("")
+                        st.rerun()
+                    else:
+                        metadata.data_sensitive = []
+                        metadata.data_sensitive.append("")
+                        st.rerun()
+            with remove:
+                if st.button("- remove sensitive"):
+                    if metadata.data_sensitive:
+                        metadata.data_sensitive.pop()
+                        st.rerun()
+
+        key = "metadata-social-impact"
+        st.text_area(
+            label=("**Social impact**. Discussion of social impact, if applicable"),
+            key=key,
+            value=metadata.data_social_impact,
+            on_change=handle_rai_change,
+            args=(RaiEvent.RAI_DATA_SOCIAL_IMPACT, metadata, key),
+        )
+        with st.expander("**Data limitations**", expanded=True):
+            if metadata.data_limitation:
+                if type(metadata.data_limitation) is list:
+                    for index, protocol in enumerate(metadata.data_limitation):
+                        key = "metadata-data-limitations_" + str(index)
+                        st.text_area(
+                            label=(
+                                "Known limitations - Data generalization limits (e.g related to data distribution, data quality issues, or data sources) and on-recommended uses."
+                            ),
+                            key=key,
+                            value=protocol,
+                            on_change=handle_rai_change,
+                            args=(RaiEvent.RAI_DATA_LIMITATION, metadata, key),
+                        )
+                else:
+                    metadata.data_limitation = [metadata.data_limitation]
+                    key = "metadata-data-limitations_" + "0"
+                    st.text_area(
+                        label=(
+                            "Known limitations - Data generalization limits (e.g related to data distribution, data quality issues, or data sources) and on-recommended uses."
+                        ),
+                        key=key,
+                        value=metadata.data_limitation,
+                        on_change=handle_rai_change,
+                        args=(RaiEvent.RAI_DATA_LIMITATION, metadata, key),
+                    )
+
+            else:
+                key = "metadata-data-limitations_" + "0"
+                st.text_area(
+                    label=(
+                        "Known limitations - Data generalization limits (e.g related to data distribution, data quality issues, or data sources) and on-recommended uses."
+                    ),
+                    key=key,
+                    on_change=handle_rai_change,
+                    args=(RaiEvent.RAI_DATA_LIMITATION, metadata, key),
+                )
+            add, remove = st.columns(2)
+            with add:
+                if st.button("+ add limitations"):
+                    if metadata.data_limitation:
+                        metadata.data_limitation.append("")
+                        st.rerun()
+                    else:
+                        metadata.data_limitation = []
+                        metadata.data_limitation.append("")
+                        st.rerun()
+            with remove:
+                if st.button("- remove limitations"):
+                    if metadata.data_limitation:
+                        metadata.data_limitation.pop()
+                        st.rerun()
+        key = "metadata-data-maintenance"
+        st.text_area(
+            label=(
+                "**Data release maintenance**. Versioning information in terms of the updating timeframe, the maintainers, and the deprecation policies. "
+            ),
+            key=key,
+            value=metadata.data_maintenance,
+            on_change=handle_rai_change,
+            args=(RaiEvent.RAI_MAINTENANCE, metadata, key),
+        )

--- a/editor/views/wizard.py
+++ b/editor/views/wizard.py
@@ -9,6 +9,7 @@ from core.constants import OVERVIEW
 from core.constants import RECORD_SETS
 from core.constants import RESOURCES
 from core.constants import TABS
+from core.constants import RAI
 from core.past_projects import save_current_project
 from core.state import get_tab
 from core.state import Metadata
@@ -18,6 +19,7 @@ from views.files import render_files
 from views.metadata import render_metadata
 from views.overview import render_overview
 from views.record_sets import render_record_sets
+from views.rai import render_rai_metadata
 
 
 def _export_json() -> str | None:
@@ -49,5 +51,7 @@ def render_editor():
         render_files()
     elif tab == RECORD_SETS:
         render_record_sets()
+    elif tab == RAI:
+        render_rai_metadata()
     save_current_project()
     set_tab(tab)


### PR DESCRIPTION
As a subsequent PR of the [library adaptation for RAI attributes](https://github.com/mlcommons/croissant/pull/553), this PR adds the RAI tab to the editor. 


The tab follows the specification in http://mlcommons.org/croissant/RAI/ (near to be published)

<img width="1352" alt="Captura de pantalla 2024-02-28 a las 12 41 37" src="https://github.com/mlcommons/croissant/assets/5485515/0fbcb992-c290-4bf9-ae32-2a6bd918389b">

There are also a few changes in the name of the serialize/deserialize function of the Python library.

After this PR, there is planned a PR to update some example datasets with RAI attributes
