### PR TITLE
Fixes in RAI 1.0 specification

### DIFF
--- a/docs/croissant-rai-spec.md
+++ b/docs/croissant-rai-spec.md
@@ -260,7 +260,7 @@ sc:<a href="https://schema.org/inLanguage">inLanguage</a>
    <td>Use case 6: Regulatory compliance
    </td>
    <td>rai:personalSensitiveInformation \
-rai:useCases rai:dataReleaseMaintenance rai:dataManipulationProtocol rai:dataManipulationProtocol rai:dataSharingAgreements rai:dataGovernanceProtocol 
+rai:useCases rai:dataReleaseMaintenance rai:dataManipulationProtocol rai:dataManipulationProtocol
    </td>
    <td>
    </td>


### PR DESCRIPTION
dataSharingAgreements and dataGovernanceProtocol are not part of the 1.0 RAI specification.