### PR TITLE
typo (formatting)

### DIFF
--- a/docs/croissant-spec.md
+++ b/docs/croissant-spec.md
@@ -684,7 +684,7 @@ stock_data_6_9_2023.csv
 stock_data_6_10_2023.csv
 ```
 
-Because the dataset is updated continuously, the dataset should set the `isLiveDataset`` property to true. Since all files are written only once, checksums can be included without risk of synchronization issues. The dataset version should only be updated if a backwards-incompatible change is made (e.g., a bug fix to a file), since it is expected that a new file will be added every day.
+Because the dataset is updated continuously, the dataset should set the `isLiveDataset` property to true. Since all files are written only once, checksums can be included without risk of synchronization issues. The dataset version should only be updated if a backwards-incompatible change is made (e.g., a bug fix to a file), since it is expected that a new file will be added every day.
 
 # Resources
 


### PR DESCRIPTION
Fixing the backticks:

![Screenshot 2024-03-20 at 4 25 28 PM](https://github.com/mlcommons/croissant/assets/21006/78dc826d-b739-42d9-8745-c8fc6c0595bd)
