### PR TITLE
Add a warning in case the user deviates from the standard JSON-LD `@context`

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/core/rdf.py
+++ b/python/mlcroissant/mlcroissant/_src/core/rdf.py
@@ -6,6 +6,7 @@ import dataclasses
 import functools
 from typing import Any
 
+from absl import logging
 from rdflib import term
 
 from mlcroissant._src.core.types import Json
@@ -71,6 +72,15 @@ class Rdf:
     def from_json(cls, ctx, json: Json) -> Rdf:
         """Creates a `Rdf` from JSON."""
         context = get_context(json)
+        # Keys that are in the standard @context, but not in the current @context.
+        different_keys = make_context(ctx).keys() - context.keys()
+        if different_keys:
+            logging.warning(
+                "WARNING: The JSON-LD `@context` is not standard. Refer to the"
+                " official @context (e.g., from the example datasets in"
+                " https://github.com/mlcommons/croissant/tree/main/datasets/1.0). The"
+                f" different keys are: {different_keys}"
+            )
         return cls(context=context)
 
     @functools.cache

--- a/python/mlcroissant/mlcroissant/_src/core/rdf_test.py
+++ b/python/mlcroissant/mlcroissant/_src/core/rdf_test.py
@@ -1,8 +1,12 @@
 """Tests for RDF."""
 
+from unittest import mock
+
+from absl import logging
 import pytest
 
 from mlcroissant._src.core.context import Context
+from mlcroissant._src.core.rdf import make_context
 from mlcroissant._src.core.rdf import Rdf
 from mlcroissant._src.tests.versions import CONFORMS_TO
 
@@ -52,3 +56,19 @@ def test_shorten_key(ctx):
     assert rdf.shorten_key("bio:bar") == "bar"
     assert rdf.shorten_key("https://bioschemas.org/baz") == "baz"
     assert rdf.shorten_key("bio:baz") == "baz"
+
+
+@mock.patch.object(logging, "warning")
+def test_from_json_without_warning(mock_warning):
+    jsonld = {"@context": make_context()}
+    rdf = Rdf.from_json(Context(), jsonld)
+    assert rdf.context == make_context()
+    mock_warning.assert_not_called()
+
+
+@mock.patch.object(logging, "warning")
+def test_from_json_with_warning(mock_warning):
+    jsonld = {"@context": {"foo": "bar"}}
+    rdf = Rdf.from_json(Context(), jsonld)
+    assert rdf.context == {"foo": "bar"}
+    mock_warning.assert_called_once()


### PR DESCRIPTION
With @goeffthomas, we realized this error is common, so we look for a way to enforce it. This is a proposal.

```
$ mlcroissant validate --jsonld https://www.kaggle.com/datasets/kaggle/meta-kaggle/croissant/download

W0327 07:30:34.631297 140699768117056 rdf.py:77] WARNING: The JSON-LD `@context` is not standard. Refer to the official @context (e.g., from the example datasets in https://github.com/mlcommons/croissant/tree/main/datasets/1.0). The different keys are: {'isEnumeration', 'wd', 'dataCollection', 'dataBiases', 'personalSensitiveInformation'}
```

The problem is that the so-called "standard datasets" in the warning message also don't have a proper `@context`, so I sent PR https://github.com/mlcommons/croissant/pull/621.

```
$ mlcroissant validate --jsonld https://raw.githubusercontent.com/mlcommons/croissant/main/datasets/1.0/titanic/metadata.json

W0327 07:31:57.376785 140040957675328 rdf.py:77] WARNING: The JSON-LD `@context` is not standard. Refer to the official @context (e.g., from the example datasets in https://github.com/mlcommons/croissant/tree/main/datasets/1.0). The different keys are: {'dataCollection', 'wd', 'personalSensitiveInformation', 'dataBiases'}
W0327 07:31:57.444254 140040957675328 datasets.py:32] Found the following 1 warning(s) during the validation:
  -  [Metadata(Titanic)] Property "https://schema.org/datePublished" is recommended, but does not exist.
I0327 07:31:57.444491 140040957675328 validate.py:53] Done.
```