### PR TITLE
Update join link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Here is an extremely simple example of the Croissant format, with comments showi
 
 ## Getting involved
 
-- [Join](https://groups.google.com/a/mlcommons.org/g/croissant) the mailing list
+- [Join](https://mlcommons.org/community/subscribe/) the mailing list
 - Attend Croissant meetings (please joint the list to automatically receive the invite)
 - [File issues for](https://github.com/mlcommons/croissant) bugs for feature requests
 - [Contribute code](https://github.com/mlcommons/croissant) (please sign the MLCommons Association CLA first!)


### PR DESCRIPTION
The current join the mailing list link in the ReadMe file is inaccessible to those not already on the mailing list. The way to join the mailing list is to submit the MLCommons subscription form. This PR updates that link accordingly.