### PR TITLE
Remove flores notebook from the automatically checked notebook.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,16 +80,7 @@ jobs:
           do
             if [ "$notebook" = "recipes/flores200_datapipes.ipynb" ]
             then
-              MAX_SEQUENCE_LENGTH="10" \
-              TRAIN_BATCH_SIZE="1" \
-              TEST_BATCH_SIZE="1" \
-              NUM_TRAIN_EPOCHS="0" \
-              TEST_FRACTION="2e-5" \
-              jupyter nbconvert \
-                --ExecutePreprocessor.timeout=600 \
-                --ExecutePreprocessor.kernel_name=croissant-notebook \
-                --to notebook \
-                --execute "$notebook"
+              echo "Skipping notebook=${notebook}"
             else
               jupyter nbconvert \
                 --ExecutePreprocessor.timeout=600 \


### PR DESCRIPTION
Reason: it seems that torchdata is not maintained anymore ([source](https://github.com/pytorch/data?tab=readme-ov-file#torchdata-see-note-below-on-current-status)) and it fails with torch versions in [2.1, 2.2, 2.3].

@mkuchnik FYI, we excluded the notebook from the GitHub Actions because it has been failing in the last >2 weeks. We unsuccessfully tried to fix the versions, probably you'll know better. Thanks!