### PR TITLE
Fix regex transform failure on FileProperty.fullpath

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field.py
@@ -34,7 +34,7 @@ def _apply_transform_fn(value: Any, transform: Transform, field: Field) -> Any:
     """Applies one transform to `value`."""
     if transform.regex is not None:
         source_regex = re.compile(transform.regex)
-        match = source_regex.match(value)
+        match = source_regex.match(str(value))
         if match is None:
             logging.warning(f"Could not match {source_regex} in {value}")
             return value

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field_test.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field_test.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from unittest import mock
+import pathlib
 
 import numpy as np
 import pandas as pd
@@ -184,6 +185,13 @@ def test_extract_lines(separator):
             Source(transforms=[Transform(regex="(train|val)\\d\\d\\d\\d")]),
             DataType.TEXT,
             "foo1234",
+        ],
+        # Regex match on pathlib.PurePath as if from FileProperty.fullpath
+        [
+            pathlib.PurePath("train1234"),
+            Source(transforms=[Transform(regex="(train|val)\\d\\d\\d\\d")]),
+            DataType.TEXT,
+            "train",
         ],
         [
             {"one": {"two": "expected_value"}, "three": "non_expected_value"},


### PR DESCRIPTION
Also add a test case which fails without the fix.  I don't know if this is the best place to cast `PurePath` to `str`, but it has the least impact here while still solving the problem.