### PR TITLE
Add URLs to pyproject.toml

### DIFF
--- a/python/mlcroissant/pyproject.toml
+++ b/python/mlcroissant/pyproject.toml
@@ -32,6 +32,11 @@ dependencies = [
 ]
 readme = "README.md"
 
+[urls]
+github = "https://github.com/mlcommons/croissant"
+documentation = "https://mlcommons.org/working-groups/data/croissant/"
+"bug tracker" = "https://github.com/mlcommons/croissant/issues"
+
 [project.optional-dependencies]
 # Development deps (linting, formatting,...)
 # Installed through `pip install -e .[dev]`


### PR DESCRIPTION
This is useful since it shows up on the PyPI sidebar for the package, which means that users will be able to easily navigate to the github, bugs, and documentation in a standardized way. Not sure what the most appropriate documentation pages would be at this point.