### PR TITLE
Isolate a `.call()` method in operations.

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/core/graphs/utils.py
+++ b/python/mlcroissant/mlcroissant/_src/core/graphs/utils.py
@@ -5,22 +5,14 @@ import time
 import networkx as nx
 
 
-def pretty_print_graph(graph: nx.Graph, simplify=False):
+def pretty_print_graph(graph: nx.Graph):
     """Pretty prints a NetworkX graph.
 
     Warning: this function is for debugging purposes only.
 
     Args:
         graph: Any NetworkX graph.
-        simplify: Whether to print a simplified version of nodes.
     """
-    if simplify:
-        simple_graph = nx.Graph()
-        for x, y in graph.edges():
-            x = getattr(x, "uid", x)
-            y = getattr(y, "uid", y)
-            simple_graph.add_edge(x, y)
-        graph = simple_graph
     agraph = nx.nx_agraph.to_agraph(graph)
     agraph.layout(prog="dot")
     temporary_file = f"/tmp/graph_{time.time()}.svg"

--- a/python/mlcroissant/mlcroissant/_src/datasets.py
+++ b/python/mlcroissant/mlcroissant/_src/datasets.py
@@ -85,11 +85,11 @@ class Dataset:
             return
         # Draw the structure graph for debugging purposes.
         if self.debug:
-            graphs_utils.pretty_print_graph(ctx.graph, simplify=True)
+            graphs_utils.pretty_print_graph(ctx.graph)
         self.operations = get_operations(ctx, self.metadata)
         # Draw the operations graph for debugging purposes.
         if self.debug:
-            graphs_utils.pretty_print_graph(self.operations.operations, simplify=False)
+            graphs_utils.pretty_print_graph(self.operations.operations)
 
     @classmethod
     def from_metadata(cls, metadata: Metadata) -> Dataset:
@@ -149,8 +149,6 @@ class Records:
         """
         # We only consider the operations that are useful to produce the `ReadFields`.
         operations = self._filter_interesting_operations(self.filters)
-        if self.debug:
-            graphs_utils.pretty_print_graph(operations)
         # Downloads can be parallelized, so we execute them in priority.
         execute_downloads(operations)
         # We can stream the dataset iff the operation graph is a path graph (meaning

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/base_operation.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/base_operation.py
@@ -91,8 +91,12 @@ class Operation(abc.ABC):
             if previous_operation != self:
                 self.operations.add_edge(previous_operation, self)
 
-    @abc.abstractmethod
     def __call__(self, *args, **kwargs):
+        """Syntactic sugar around self.call to write `operation()`."""
+        return self.call(*args, **kwargs)
+
+    @abc.abstractmethod
+    def call(self, *args, **kwargs):
         """Abstract method to implement when an operation is called."""
         raise NotImplementedError
 

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/concatenate.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/concatenate.py
@@ -17,7 +17,7 @@ class Concatenate(Operation):
 
     node: FileSet
 
-    def __call__(self, *args: list[Path]) -> pd.DataFrame:
+    def call(self, *args: list[Path]) -> pd.DataFrame:
         """See class' docstring."""
         assert len(args) > 0, "No dataframe to merge."
         files = [file for files in args for file in files]

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/data.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/data.py
@@ -14,7 +14,7 @@ class Data(Operation):
 
     node: RecordSet
 
-    def __call__(self, *args) -> pd.DataFrame:
+    def call(self, *args) -> pd.DataFrame:
         """See class' docstring."""
         del args  # unused
         return pd.DataFrame.from_records(self.node.data)

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/download.py
@@ -218,7 +218,7 @@ class Download(Operation):
             repo.remote().fetch(f"{refs}:{branch_name}")
             repo.branches[branch_name].checkout()
 
-    def __call__(self, *args) -> Path:
+    def call(self, *args) -> Path:
         """See class' docstring."""
         del args  # unused
         filepath = get_download_filepath(self.node)

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/extract.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/extract.py
@@ -42,7 +42,7 @@ class Extract(Operation):
 
     node: FileObject
 
-    def __call__(self, archive_file: Path) -> Path:
+    def call(self, archive_file: Path) -> Path:
         """See class' docstring."""
         url = self.node.content_url
         assert url, "Content of URL for this node is None"

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field.py
@@ -157,7 +157,7 @@ class ReadFields(Operation):
                 fields.append(field)
         return fields
 
-    def __call__(self, df: pd.DataFrame) -> Iterator[dict[str, Any]]:
+    def call(self, df: pd.DataFrame) -> Iterator[dict[str, Any]]:
         """See class' docstring."""
         if self.node.data:
             # The RecordSet has `data`, so we directly yield from the dataframe.

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/filter.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/filter.py
@@ -38,7 +38,7 @@ class FilterFiles(Operation):
 
     node: FileSet
 
-    def __call__(self, *paths: Path) -> list[Path]:
+    def call(self, *paths: Path) -> list[Path]:
         """See class' docstring."""
         if self.node.includes is None:
             raise ValueError("cannot filter files without `includes`.")

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/init.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/init.py
@@ -10,7 +10,7 @@ from mlcroissant._src.operation_graph.base_operation import Operation
 class InitOperation(Operation):
     """Sets up other operations."""
 
-    def __call__(self, *args):
+    def call(self, *args):
         """See class' docstring."""
         del args  # unused
         logging.info("Setting up generation for dataset: %s", self.node.uuid)

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/join.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/join.py
@@ -18,7 +18,7 @@ class Join(Operation):
 
     node: RecordSet
 
-    def __call__(self, *args: pd.Series) -> pd.Series | None:
+    def call(self, *args: pd.Series) -> pd.Series | None:
         """See class' docstring."""
         if len(args) == 1:
             return args[0]

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/local_directory.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/local_directory.py
@@ -16,9 +16,9 @@ class LocalDirectory(Operation):
     node: FileSet
     folder: epath.Path
 
-    def __call__(self, *args):
+    def call(self, *args):
         """See class' docstring."""
-        del args
+        del args  # unused
         return Path(
             filepath=self.folder,
             fullpath=self.folder,

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/read.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/read.py
@@ -138,7 +138,7 @@ class Read(Operation):
                     f"Unsupported encoding format for file: {encoding_format}"
                 )
 
-    def __call__(self, files: list[Path] | Path) -> pd.DataFrame:
+    def call(self, files: list[Path] | Path) -> pd.DataFrame:
         """See class' docstring."""
         if isinstance(files, Path):
             files = [files]


### PR DESCRIPTION
- [Simplify graph printing.](https://github.com/mlcommons/croissant/pull/736/commits/a3d42557f65add58fb4e2888d1aebe591451a201)
- [Isolate a .call() method in operations.](https://github.com/mlcommons/croissant/pull/736/commits/36e1d21dc536ceb150aeb6316a5a43aab13d74f8)

Later, the goal is to have the `.call()` method to populate an internal cache.

Pseudo-code for next PRs:

```python
class Operation:
  _output: Any = dataclass(init=False)

  def __call__(...):
    if self._output:
      return self._output
    result = self.call(...)
    self._output = result
    return result
```

This would allow to retrieve the result of any operation by calling `operation()` - without argument. This should hopefully simplify the logic of making data flow in the graph of operations.

In the context of the Beam pipeline, this would allow us to generate intermediary steps (like intermediary RecordSets for joins for example) more easily.

When we don't want to use the cache (e.g., in the case of streamable datasets), we can just use operation.call() as we would normally do.