### PR TITLE
Keys in a RecordSet should be a list of ids references.

### DIFF
--- a/datasets/1.0/coco2014-mini/metadata.json
+++ b/datasets/1.0/coco2014-mini/metadata.json
@@ -97,7 +97,9 @@
       "@id": "split_enums",
       "name": "split_enums",
       "description": "Maps split names to semantic values.",
-      "key": "name",
+      "key": {
+        "@id": "name"
+      },
       "field": [
         {
           "@type": "cr:Field",
@@ -136,7 +138,9 @@
       "@type": "cr:RecordSet",
       "@id": "images",
       "name": "images",
-      "key": "img_id",
+      "key": {
+        "@id": "img_id"
+      },
       "field": [
         {
           "@type": "cr:Field",
@@ -199,7 +203,9 @@
       "@type": "cr:RecordSet",
       "@id": "captions",
       "name": "captions",
-      "key": "id",
+      "key": {
+        "@id": "id"
+      },
       "field": [
         {
           "@type": "cr:Field",

--- a/datasets/1.0/coco2014/index.html
+++ b/datasets/1.0/coco2014/index.html
@@ -131,7 +131,9 @@
         "@type": "ml:RecordSet",
         "name": "split_enums",
         "description": "Maps split names to semantic values.",
-        "key": "name",
+        "key": {
+          "@id": "name"
+        },
         "field": [
           {
             "@type": "ml:Field",
@@ -167,7 +169,9 @@
       {
         "@type": "ml:RecordSet",
         "name": "images",
-        "key": "image_id",
+        "key": {
+            "@id": "image_id"
+        },
         "field": [
           {
             "@type": "ml:Field",
@@ -233,7 +237,9 @@
       {
         "@type": "ml:RecordSet",
         "name": "captions",
-        "key": "id",
+        "key": {
+            "@id": "id"
+        },
         "field": [
           {
             "@type": "ml:Field",
@@ -300,7 +306,9 @@
         "@type": "ml:RecordSet",
         "name": "categories",
         "isEnumeration": true,
-        "key": "id",
+        "key": {
+          "@id": "id"
+        },
         "field": [
           {
             "@type": "ml:Field",
@@ -350,7 +358,9 @@
       {
         "@type": "ml:RecordSet",
         "name": "annotations",
-        "key": "id",
+        "key": {
+          "@id": "id"
+        },
         "field": [
           {
             "@type": "ml:Field",

--- a/datasets/1.0/coco2014/metadata.json
+++ b/datasets/1.0/coco2014/metadata.json
@@ -163,7 +163,9 @@
       "@id": "split_enums",
       "name": "split_enums",
       "description": "Maps split names to semantic values.",
-      "key": "name",
+      "key": {
+        "@id": "name"
+      },
       "field": [
         {
           "@type": "cr:Field",
@@ -202,7 +204,9 @@
       "@type": "cr:RecordSet",
       "@id": "images",
       "name": "images",
-      "key": "image_id",
+      "key": {
+        "@id": "image_id"
+      },
       "field": [
         {
           "@type": "cr:Field",
@@ -283,7 +287,9 @@
       "@type": "cr:RecordSet",
       "@id": "captions",
       "name": "captions",
-      "key": "id",
+      "key": {
+        "@id": "id"
+      },
       "field": [
         {
           "@type": "cr:Field",
@@ -365,7 +371,9 @@
       "@id": "categories",
       "name": "categories",
       "dataType": "sc:Enumeration",
-      "key": "id",
+      "key": {
+        "@id": "id"
+      },
       "field": [
         {
           "@type": "cr:Field",
@@ -425,7 +433,9 @@
       "@type": "cr:RecordSet",
       "@id": "annotations",
       "name": "annotations",
-      "key": "id",
+      "key": {
+        "@id": "id"
+      },
       "field": [
         {
           "@type": "cr:Field",

--- a/datasets/1.0/huggingface-anthropic-hh-rlhf/metadata.json
+++ b/datasets/1.0/huggingface-anthropic-hh-rlhf/metadata.json
@@ -125,7 +125,9 @@
       "@id": "split_enums",
       "name": "split_enums",
       "dataType": "cr:Split",
-      "key": "name",
+      "key": {
+        "@id": "name"
+      },
       "field": [
         {
           "@type": "cr:Field",

--- a/datasets/1.0/huggingface-mnist/metadata.json
+++ b/datasets/1.0/huggingface-mnist/metadata.json
@@ -78,25 +78,29 @@
     {
       "@type": "cr:RecordSet",
       "dataType": "cr:Split",
-      "key": "name",
+      "key": [
+        {
+          "@id": "mnist_splits/split_name"
+        }
+      ],
       "@id": "mnist_splits",
       "name": "mnist_splits",
       "description": "Splits for the mnist config.",
       "field": [
         {
           "@type": "cr:Field",
-          "@id": "mnist_splits/name",
-          "name": "name",
+          "@id": "mnist_splits/split_name",
+          "name": "split_name",
           "description": "The name of the split.",
           "dataType": "sc:Text"
         }
       ],
       "data": [
         {
-          "name": "train"
+          "split_name": "train"
         },
         {
-          "name": "test"
+          "split_name": "test"
         }
       ]
     },
@@ -125,7 +129,7 @@
           },
           "references": {
             "field": {
-              "@id": "mnist_splits/name"
+              "@id": "mnist_splits/split_name"
             }
           }
         },

--- a/datasets/1.0/huggingface-mnist/metadata.json
+++ b/datasets/1.0/huggingface-mnist/metadata.json
@@ -78,11 +78,9 @@
     {
       "@type": "cr:RecordSet",
       "dataType": "cr:Split",
-      "key": [
-        {
-          "@id": "mnist_splits/split_name"
-        }
-      ],
+      "key": {
+        "@id": "mnist_splits/split_name"
+      },
       "@id": "mnist_splits",
       "name": "mnist_splits",
       "description": "Splits for the mnist config.",

--- a/datasets/1.0/movielens/index.html
+++ b/datasets/1.0/movielens/index.html
@@ -94,7 +94,9 @@
     {
       "@type": "ml:RecordSet",
       "name": "movies",
-      "key": "movie_id",
+      "key": {
+        "@id": "movie_id"
+      },
       "field": [
         {
           "@type": "ml:Field",
@@ -141,8 +143,8 @@
       "@type": "ml:RecordSet",
       "name": "ratings",
       "key": [
-        "user_id",
-        "movie_id"
+        {"@id": "user_id"},
+        {"@id": "movie_id"},
       ],
       "field": [
         {
@@ -257,7 +259,9 @@
     {
       "@type": "ml:RecordSet",
       "name": "movies_with_ratings_with_tags",
-      "key": "movie_id",
+      "key": {
+        "@id": "movie_id"
+      },
       "field": [
         {
           "@type": "ml:Field",

--- a/datasets/1.0/movielens/metadata.json
+++ b/datasets/1.0/movielens/metadata.json
@@ -124,7 +124,9 @@
       "@type": "cr:RecordSet",
       "@id": "movies",
       "name": "movies",
-      "key": "movie_id",
+      "key": {
+        "@id": "movie_id"
+      },
       "field": [
         {
           "@type": "cr:Field",
@@ -181,8 +183,12 @@
       "@id": "ratings",
       "name": "ratings",
       "key": [
-        "user_id",
-        "movie_id"
+        {
+          "@id": "user_id"
+        },
+        {
+          "@id": "movie_id"
+        }
       ],
       "field": [
         {
@@ -254,9 +260,15 @@
       "@id": "tags",
       "name": "tags",
       "key": [
-        "user_id",
-        "movie_id",
-        "timestamp"
+        {
+          "@id": "user_id"
+        },
+        {
+          "@id": "movie_id"
+        },
+        {
+          "@id": "timestamp"
+        }
       ],
       "field": [
         {
@@ -327,7 +339,9 @@
       "@type": "cr:RecordSet",
       "@id": "movies_with_ratings_with_tags",
       "name": "movies_with_ratings_with_tags",
-      "key": "movie_id",
+      "key": {
+        "@id": "movie_id"
+      },
       "field": [
         {
           "@type": "cr:Field",

--- a/datasets/1.0/pass-mini/metadata.json
+++ b/datasets/1.0/pass-mini/metadata.json
@@ -97,7 +97,9 @@
       "@type": "cr:RecordSet",
       "@id": "images",
       "name": "images",
-      "key": "hash",
+      "key": {
+        "@id": "hash"
+      },
       "field": [
         {
           "@type": "cr:Field",

--- a/datasets/1.0/pass/index.html
+++ b/datasets/1.0/pass/index.html
@@ -142,7 +142,9 @@
     {
       "@type": "ml:RecordSet",
       "name": "images",
-      "key": "hash",
+      "key": {
+        "@id": "hash"
+      },
       "field": [
         {
           "@type": "ml:Field",

--- a/datasets/1.0/pass/metadata.json
+++ b/datasets/1.0/pass/metadata.json
@@ -185,7 +185,9 @@
       "@type": "cr:RecordSet",
       "@id": "images",
       "name": "images",
-      "key": "hash",
+      "key": {
+        "@id": "hash"
+      },
       "field": [
         {
           "@type": "cr:Field",

--- a/datasets/1.0/recipes/enum.json
+++ b/datasets/1.0/recipes/enum.json
@@ -78,7 +78,9 @@
       "@id": "direction_enum",
       "name": "direction_enum",
       "description": "Maps compass direction keys (0, 1, 2, 3) to labeled values.",
-      "key": "key",
+      "key": {
+        "@id": "key"
+      },
       "field": [
         {
           "@type": "cr:Field",

--- a/datasets/1.0/recipes/live_dataset.json
+++ b/datasets/1.0/recipes/live_dataset.json
@@ -65,7 +65,9 @@
       "@id": "direction_enum",
       "name": "direction_enum",
       "description": "Maps compass direction keys (0, 1, 2, 3) to labeled values.",
-      "key": "key",
+      "key": {
+        "@id": "key"
+      },
       "field": [
         {
           "@type": "cr:Field",

--- a/datasets/1.0/titanic/index.html
+++ b/datasets/1.0/titanic/index.html
@@ -115,7 +115,9 @@
       "name": "embarkation_ports",
       "description": "Maps Embarkation port initial to labeled values.",
       "isEnumeration": true,
-      "key": "key",
+      "key": {
+        "@id": "key"
+      },
       "field": [
         {
           "@type": "ml:Field",

--- a/datasets/1.0/titanic/metadata.json
+++ b/datasets/1.0/titanic/metadata.json
@@ -109,7 +109,7 @@
               "@id": "genders.csv"
             },
             "extract": {
-              "column": "label"
+              "column": "genders/label"
             }
           }
         },
@@ -139,12 +139,14 @@
       "name": "embarkation_ports",
       "description": "Maps Embarkation port initial to labeled values.",
       "dataType": "sc:Enumeration",
-      "key": "key",
+      "key": {
+        "@id": "embarkation_ports/key"
+      },
       "field": [
         {
           "@type": "cr:Field",
           "@id": "embarkation_ports/key",
-          "name": "key",
+          "name": "embarkation_ports/key",
           "description": "C, Q, S or ?",
           "dataType": "sc:Text",
           "source": {
@@ -152,7 +154,7 @@
               "@id": "embarkation_ports.csv"
             },
             "extract": {
-              "column": "key"
+              "column": "embarkation_ports/key"
             }
           }
         },

--- a/datasets/1.0/titanic/metadata.json
+++ b/datasets/1.0/titanic/metadata.json
@@ -91,12 +91,14 @@
       "name": "genders",
       "description": "Maps gender labels to semantic definitions.",
       "dataType": "sc:Enumeration",
-      "key": "label",
+      "key": {
+        "@id": "genders/label"
+      },
       "field": [
         {
           "@type": "cr:Field",
           "@id": "genders/label",
-          "name": "label",
+          "name": "genders/label",
           "description": "One of {\"male\", \"female\"}",
           "dataType": [
             "sc:Text",

--- a/datasets/1.0/titanic/metadata.json
+++ b/datasets/1.0/titanic/metadata.json
@@ -139,9 +139,14 @@
       "name": "embarkation_ports",
       "description": "Maps Embarkation port initial to labeled values.",
       "dataType": "sc:Enumeration",
-      "key": {
-        "@id": "embarkation_ports/key"
-      },
+      "key": [
+        {
+          "@id": "embarkation_ports/key"
+        },
+        {
+          "@id": "embarkation_ports/key2"
+        }
+      ],
       "field": [
         {
           "@type": "cr:Field",

--- a/datasets/1.0/titanic/metadata.json
+++ b/datasets/1.0/titanic/metadata.json
@@ -139,14 +139,9 @@
       "name": "embarkation_ports",
       "description": "Maps Embarkation port initial to labeled values.",
       "dataType": "sc:Enumeration",
-      "key": [
-        {
-          "@id": "embarkation_ports/key"
-        },
-        {
-          "@id": "embarkation_ports/key2"
-        }
-      ],
+      "key": {
+        "@id": "embarkation_ports/key"
+      },
       "field": [
         {
           "@type": "cr:Field",

--- a/datasets/1.0/titanic/metadata.json
+++ b/datasets/1.0/titanic/metadata.json
@@ -98,7 +98,7 @@
         {
           "@type": "cr:Field",
           "@id": "genders/label",
-          "name": "genders/label",
+          "name": "label",
           "description": "One of {\"male\", \"female\"}",
           "dataType": [
             "sc:Text",
@@ -109,7 +109,7 @@
               "@id": "genders.csv"
             },
             "extract": {
-              "column": "genders/label"
+              "column": "label"
             }
           }
         },
@@ -146,7 +146,7 @@
         {
           "@type": "cr:Field",
           "@id": "embarkation_ports/key",
-          "name": "embarkation_ports/key",
+          "name": "key",
           "description": "C, Q, S or ?",
           "dataType": "sc:Text",
           "source": {
@@ -154,7 +154,7 @@
               "@id": "embarkation_ports.csv"
             },
             "extract": {
-              "column": "embarkation_ports/key"
+              "column": "key"
             }
           }
         },

--- a/datasets/1.0/wiki-text/metadata.json
+++ b/datasets/1.0/wiki-text/metadata.json
@@ -86,7 +86,9 @@
       "@id": "split_enums",
       "name": "split_enums",
       "description": "Maps split names to semantic values.",
-      "key": "name",
+      "key": {
+        "@id": "name"
+      },
       "field": [
         {
           "@type": "cr:Field",

--- a/editor/cypress/fixtures/1.0/coco2014.json
+++ b/editor/cypress/fixtures/1.0/coco2014.json
@@ -163,7 +163,9 @@
       "@id": "split_enums",
       "name": "split_enums",
       "description": "Maps split names to semantic values.",
-      "key": "name",
+      "key": {
+        "@id": "name"
+      },
       "field": [
         {
           "@type": "cr:Field",
@@ -202,7 +204,9 @@
       "@type": "cr:RecordSet",
       "@id": "images",
       "name": "images",
-      "key": "image_id",
+      "key": {
+        "@id": "image_id"
+      },
       "field": [
         {
           "@type": "cr:Field",
@@ -283,7 +287,9 @@
       "@type": "cr:RecordSet",
       "@id": "captions",
       "name": "captions",
-      "key": "id",
+      "key": {
+        "@id": "id"
+      },
       "field": [
         {
           "@type": "cr:Field",
@@ -365,7 +371,9 @@
       "@id": "categories",
       "name": "categories",
       "dataType": "sc:Enumeration",
-      "key": "id",
+      "key": {
+        "@id": "id"
+      },
       "field": [
         {
           "@type": "cr:Field",
@@ -425,7 +433,9 @@
       "@type": "cr:RecordSet",
       "@id": "annotations",
       "name": "annotations",
-      "key": "id",
+      "key": {
+        "@id": "id"
+      },
       "field": [
         {
           "@type": "cr:Field",

--- a/editor/cypress/fixtures/1.0/titanic.json
+++ b/editor/cypress/fixtures/1.0/titanic.json
@@ -92,7 +92,7 @@
       "description": "Maps gender labels to semantic definitions.",
       "dataType": "sc:Enumeration",
       "key": {
-        "@id": "label"
+        "@id": "genders/label"
       },
       "field": [
         {
@@ -109,7 +109,7 @@
               "@id": "genders.csv"
             },
             "extract": {
-              "column": "label"
+              "column": "genders/label"
             }
           }
         },
@@ -139,12 +139,14 @@
       "name": "embarkation_ports",
       "description": "Maps Embarkation port initial to labeled values.",
       "dataType": "sc:Enumeration",
-      "key": "key",
+      "key": {
+        "@id": "embarkation_ports/key"
+      },
       "field": [
         {
           "@type": "cr:Field",
           "@id": "embarkation_ports/key",
-          "name": "key",
+          "name": "embarkation_ports/key",
           "description": "C, Q, S or ?",
           "dataType": "sc:Text",
           "source": {
@@ -152,7 +154,7 @@
               "@id": "embarkation_ports.csv"
             },
             "extract": {
-              "column": "key"
+              "column": "embarkation_ports/key"
             }
           }
         },

--- a/editor/cypress/fixtures/1.0/titanic.json
+++ b/editor/cypress/fixtures/1.0/titanic.json
@@ -91,12 +91,14 @@
       "name": "genders",
       "description": "Maps gender labels to semantic definitions.",
       "dataType": "sc:Enumeration",
-      "key": "label",
+      "key": {
+        "@id": "label"
+      },
       "field": [
         {
           "@type": "cr:Field",
           "@id": "genders/label",
-          "name": "label",
+          "name": "genders/label",
           "description": "One of {\"male\", \"female\"}",
           "dataType": [
             "sc:Text",

--- a/editor/cypress/fixtures/1.0/titanic.json
+++ b/editor/cypress/fixtures/1.0/titanic.json
@@ -98,7 +98,7 @@
         {
           "@type": "cr:Field",
           "@id": "genders/label",
-          "name": "genders/label",
+          "name": "label",
           "description": "One of {\"male\", \"female\"}",
           "dataType": [
             "sc:Text",
@@ -109,7 +109,7 @@
               "@id": "genders.csv"
             },
             "extract": {
-              "column": "genders/label"
+              "column": "label"
             }
           }
         },
@@ -146,7 +146,7 @@
         {
           "@type": "cr:Field",
           "@id": "embarkation_ports/key",
-          "name": "embarkation_ports/key",
+          "name": "key",
           "description": "C, Q, S or ?",
           "dataType": "sc:Text",
           "source": {
@@ -154,7 +154,7 @@
               "@id": "embarkation_ports.csv"
             },
             "extract": {
-              "column": "embarkation_ports/key"
+              "column": "key"
             }
           }
         },

--- a/python/mlcroissant/mlcroissant/_src/core/uuid.py
+++ b/python/mlcroissant/mlcroissant/_src/core/uuid.py
@@ -37,10 +37,10 @@ def uuid_to_jsonld(uuid: str | None) -> str | None:
 
 def formatted_uuid_to_json(
     ctx: Context, uuid: None | str | list[str]
-) -> str | None | dict[str, Any] | list[dict[str, Any]]:
+) -> str | dict[str, Any] | list[dict[str, Any]] | None:
     """Return a formatted node's uuid depending on the Croissant version."""
     if ctx.is_v0():
-        return uuid
+        return uuid  # type: ignore  # Force mypy types.
     else:
         if isinstance(uuid, list):
             if len(uuid) == 1:

--- a/python/mlcroissant/mlcroissant/_src/core/uuid.py
+++ b/python/mlcroissant/mlcroissant/_src/core/uuid.py
@@ -36,10 +36,18 @@ def uuid_to_jsonld(uuid: str | None) -> str | None:
 
 
 def formatted_uuid_to_json(
-    ctx: Context, uuid: None | str
-) -> str | None | dict[str, Any]:
+    ctx: Context, uuid: None | str | list[str]
+) -> str | None | dict[str, Any] | list[dict[str, Any]]:
     """Return a formatted node's uuid depending on the Croissant version."""
     if ctx.is_v0():
         return uuid
     else:
-        return {"@id": uuid}
+        if isinstance(uuid, list):
+            if len(uuid) == 1:
+                return {"@id": uuid[0]}
+            else:
+                return [{"@id": _uuid} for _uuid in uuid]
+        elif isinstance(uuid, str):
+            return {"@id": uuid}
+        else:
+            raise ValueError(f"Unknown uuid type: uuid is of type {type(uuid)}.")

--- a/python/mlcroissant/mlcroissant/_src/core/uuid_test.py
+++ b/python/mlcroissant/mlcroissant/_src/core/uuid_test.py
@@ -43,6 +43,12 @@ def test_uuid_to_jsonld(input, output):
     [
         [CroissantVersion.V_0_8, "example/uuid", "example/uuid"],
         [CroissantVersion.V_1_0, "example/uuid", {"@id": "example/uuid"}],
+        [
+            CroissantVersion.V_1_0,
+            ["example/uuid1", "example/uuid2"],
+            [{"@id": "example/uuid1"}, {"@id": "example/uuid2"}],
+        ],
+        [CroissantVersion.V_1_0, ["example/uuid1"], {"@id": "example/uuid1"}],
     ],
 )
 def test_formatted_uuid_to_json(conforms_to, uuid, output):

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
@@ -444,6 +444,9 @@ def _value_from_input_types(
             actual_jsonld_type = value.get("@type")
             if actual_jsonld_type == jsonld_type:
                 return input_type.from_jsonld(ctx, value)
+        # ...or it is a dictionary of keys...
+        elif isinstance(value, dict) and field.name == 'key':
+            return None
         # ...or it's a basic int/str/bool/etc type
         else:
             matching_type = MATCHING_TYPES.get(input_type)

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
@@ -445,7 +445,7 @@ def _value_from_input_types(
             if actual_jsonld_type == jsonld_type:
                 return input_type.from_jsonld(ctx, value)
         # ...or it is a dictionary of keys...
-        elif isinstance(value, dict) and field.name == 'key':
+        elif isinstance(value, dict) and field.name == "key":
             return None
         # ...or it's a basic int/str/bool/etc type
         else:

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/base_node.py
@@ -444,9 +444,6 @@ def _value_from_input_types(
             actual_jsonld_type = value.get("@type")
             if actual_jsonld_type == jsonld_type:
                 return input_type.from_jsonld(ctx, value)
-        # ...or it is a dictionary of keys...
-        elif isinstance(value, dict) and field.name == "key":
-            return None
         # ...or it's a basic int/str/bool/etc type
         else:
             matching_type = MATCHING_TYPES.get(input_type)

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set.py
@@ -12,11 +12,11 @@ from mlcroissant._src.core.context import Context
 from mlcroissant._src.core.data_types import data_types_from_jsonld
 from mlcroissant._src.core.data_types import data_types_to_jsonld
 from mlcroissant._src.core.types import Json
+from mlcroissant._src.core.uuid import formatted_uuid_to_json
+from mlcroissant._src.core.uuid import uuid_from_jsonld
 from mlcroissant._src.structure_graph.base_node import Node
 from mlcroissant._src.structure_graph.base_node import node_by_uuid
 from mlcroissant._src.structure_graph.nodes.field import Field
-from mlcroissant._src.core.uuid import formatted_uuid_to_json
-from mlcroissant._src.core.uuid import uuid_from_jsonld
 
 
 def json_from_jsonld(ctx: Context, data) -> Json | None:

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set.py
@@ -15,6 +15,8 @@ from mlcroissant._src.core.types import Json
 from mlcroissant._src.structure_graph.base_node import Node
 from mlcroissant._src.structure_graph.base_node import node_by_uuid
 from mlcroissant._src.structure_graph.nodes.field import Field
+from mlcroissant._src.core.uuid import formatted_uuid_to_json
+from mlcroissant._src.core.uuid import uuid_from_jsonld
 
 
 def json_from_jsonld(ctx: Context, data) -> Json | None:
@@ -79,7 +81,8 @@ class RecordSet(Node):
             "One or more fields whose values uniquely identify each record in the"
             " `RecordSet`."
         ),
-        input_types=[SDO.Text],
+        from_jsonld=lambda ctx, jsonld: uuid_from_jsonld(jsonld),
+        to_jsonld=formatted_uuid_to_json,
         url=constants.SCHEMA_ORG_KEY,
     )
     name: str = mlc_dataclasses.jsonld_field(

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set_test.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/record_set_test.py
@@ -14,7 +14,6 @@ from mlcroissant._src.structure_graph.nodes.record_set import RecordSet
 from mlcroissant._src.tests.nodes import create_test_field
 from mlcroissant._src.tests.nodes import create_test_node
 from mlcroissant._src.tests.nodes import create_test_record_set
-from mlcroissant._src.tests.versions import parametrize_conforms_to
 
 
 @pytest.mark.parametrize(
@@ -75,16 +74,15 @@ def test_checks_are_performed(conforms_to, field_uuid):
         validate_name_mock.assert_called_once()
 
 
-@parametrize_conforms_to()
-def test_from_jsonld(conforms_to: CroissantVersion):
-    ctx = Context(conforms_to=conforms_to)
+def test_from_jsonld():
+    ctx = Context()
     jsonld = {
         "@type": constants.ML_COMMONS_RECORD_SET_TYPE(ctx),
         "@id": "foo_id",
         constants.SCHEMA_ORG_NAME: "foo",
         constants.SCHEMA_ORG_DESCRIPTION: "bar",
         constants.ML_COMMONS_IS_ENUMERATION(ctx): True,
-        constants.SCHEMA_ORG_KEY(ctx): ["key1", "key2"],
+        constants.SCHEMA_ORG_KEY(ctx): [{"@id": "key1"}, {"@id": "key2"}],
         constants.ML_COMMONS_DATA(ctx): '[{"column1": ["value1", "value2"]}]',
     }
     record_set = RecordSet.from_jsonld(ctx, jsonld)

--- a/python/mlcroissant/mlcroissant/scripts/migrations/migrate.py
+++ b/python/mlcroissant/mlcroissant/scripts/migrations/migrate.py
@@ -28,7 +28,7 @@ function.
 python mlcroissant/scripts/migrations/migrate.py --migration 202307171508
 ```
 
-Commiting your migration allows to keep track of previous migrations in the codebase.
+Committing your migration allows to keep track of previous migrations in the codebase.
 """
 
 import importlib


### PR DESCRIPTION
As keys, RecordSets in Croissant accept a list of dictionaries in the form:

1. `"key": [{ "@id": "ratings/user_id" }, { "@id": "ratings/movie_id" }],`
2. `"key": { "@id": "ratings/user_id" },`

As indicated the [specs](https://docs.mlcommons.org/croissant/docs/croissant-spec.html#field).

Plain keys such as `"key": "ratings/user_id"` are not accepted anymore.

