### PR TITLE
Don't handle untested and bugged case for `excludes`.

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/filter.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/filter.py
@@ -49,8 +49,7 @@ class FilterFiles(Operation):
                     filepath = epath.Path(basepath) / file
                     fullpath = get_fullpath(filepath, path.filepath)
                     match_includes = match_path(self.node.includes, fullpath)
-                    match_excludes = match_path(self.node.excludes, fullpath)
-                    if match_includes and match_excludes:
+                    if match_includes:
                         included_files.append(
                             Path(
                                 filepath=filepath,

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_set.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/file_set.py
@@ -41,10 +41,14 @@ class FileSet(Node):
         input_types=[SDO.Text],
         url=SDO.encodingFormat,
     )
+    # TODO(https://github.com/mlcommons/croissant/issues/772): Support in mlcroissant.
     excludes: list[str] | None = mlc_dataclasses.jsonld_field(
         cardinality="MANY",
         default=None,
-        description="A glob pattern that specifies the files to exclude.",
+        description=(
+            "A glob pattern that specifies the files to exclude. Warning: This feature"
+            " is not implemented yet in mlcroissant, so this is a no-op."
+        ),
         input_types=[SDO.Text],
         url=lambda ctx: constants.ML_COMMONS_EXCLUDES(ctx),
     )


### PR DESCRIPTION
At the moment, there's a bug. We should properly test this feature. For the time being, I remove the condition with the bug.