### PR TITLE
Add Python version requirement to project metadata

### DIFF
--- a/python/mlcroissant/pyproject.toml
+++ b/python/mlcroissant/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
   { name = "Pierre Ruyssen" },
   { name = "Prabhant Singh" },
 ]
-
+requires-python = ">= 3.10"
 # pip dependencies of the project
 # Installed locally with `pip install -e .`
 dependencies = [


### PR DESCRIPTION
Although the package requires Python>=3.10 it can still be installed in lower versions of Python because the requirement is not listed in the project metadata, so PyPI can't prevent it.