### PR TITLE
[URGENT] pinning version of dependency for editor

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY ./ /app/
 
-RUN python3 -m pip install -r requirements.txt
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 8501
 

--- a/editor/requirements.txt
+++ b/editor/requirements.txt
@@ -7,5 +7,5 @@ python-magic
 rdflib
 requests
 streamlit
-streamlit-nested-layout
+streamlit-nested-layout==0.1.4
 twisted


### PR DESCRIPTION
you might have noticed the HF space that holds the croissant editor was out of date and is now completely broken. I've been trying to figure out why - it's a dependency issue with streamlit-nested-layout, but it's impossible to replicate in local tests in the docker container or even in venvs. 

locally, version 0.1.2 of the library has a similar error with up-to-date streamlit versions, and I'm thinking that the HF space (when it creates the container) has some sort of caching that means it's loading 0.1.2 rather than 0.1.4 (which works as intended).

So, this PR is just a pin in requirements.txt and an instruction to not cache in Dockerfile to maybe avoid that problem. Locally this works, but it seems it's a dice roll on whether it will work on HF.

NOTE - commits to editor files here do not change the HF space. 

LONG TERM - should remove dependency on streamlit-nested-layout, which is serviced by two people and doesn't offer tons of value. I guess we might move away from streamlit anyway. 