### PR TITLE
[editor] Added support for displaying and editing `RecordSet` data types and `Field` equivalentProperty

### DIFF
--- a/editor/core/state.py
+++ b/editor/core/state.py
@@ -167,6 +167,7 @@ class Field(Node):
 
     description: str | None = None
     data_types: str | list[str] | None = None
+    equivalentProperty: str | list[str] | None = None
     source: mlc.Source | None = None
     references: mlc.Source | None = None
 

--- a/editor/events/fields.py
+++ b/editor/events/fields.py
@@ -61,6 +61,7 @@ class FieldEvent(enum.Enum):
     ID = "ID"
     DESCRIPTION = "DESCRIPTION"
     DATA_TYPE = "DATA_TYPE"
+    EQUIVALENT_PROPERTY = "EQUIVALENT_PROPERTY"
     SOURCE = "SOURCE"
     SOURCE_EXTRACT = "SOURCE_EXTRACT"
     SOURCE_EXTRACT_COLUMN = "SOURCE_EXTRACT_COLUMN"
@@ -95,6 +96,8 @@ def handle_field_change(
             metadata.rename_id(old_id=old_id, new_id=new_id)
     elif change == FieldEvent.DESCRIPTION:
         field.description = value
+    elif change == FieldEvent.EQUIVALENT_PROPERTY:
+        field.equivalentProperty = value
     elif change == FieldEvent.DATA_TYPE:
         field.data_types = [str_to_mlc_data_type(value)]
     elif change == FieldEvent.SOURCE:

--- a/editor/events/record_sets.py
+++ b/editor/events/record_sets.py
@@ -13,6 +13,7 @@ class RecordSetEvent(enum.Enum):
     NAME = "NAME"
     ID = "ID"
     DESCRIPTION = "DESCRIPTION"
+    DATA_TYPES = "DATA_TYPES"
     IS_ENUMERATION = "IS_ENUMERATION"
     HAS_DATA = "HAS_DATA"
     CHANGE_DATA = "CHANGE_DATA"
@@ -35,6 +36,8 @@ def handle_record_set_change(event: RecordSetEvent, record_set: RecordSet, key: 
             metadata.rename_id(old_id=old_id, new_id=new_id)
     elif event == RecordSetEvent.DESCRIPTION:
         record_set.description = value
+    elif event == RecordSetEvent.DATA_TYPES:
+        record_set.data_types = [value.strip() for value in value.split(',')]
     elif event == RecordSetEvent.IS_ENUMERATION:
         record_set.is_enumeration = value
     elif event == RecordSetEvent.HAS_DATA:

--- a/editor/views/jsonld.py
+++ b/editor/views/jsonld.py
@@ -32,6 +32,7 @@ def render_jsonld():
                         name=field["name"],
                         description=field["description"],
                         data_types=field["data_type"],
+                        equivalentProperty=field["equivalentProperty"],
                         source=mlc.Source(
                             distribution=file.name,
                             extract=mlc.Extract(column=field["name"]),


### PR DESCRIPTION
Currently those features are not observable or editable in the editor, but they are important to give clearer meaning to the records and fields.

- For now the RecordSet dataTypes are shown in 1 text box with each data type separated by a comma. It could be changed to a button and multiple fields, but that would be a lot more code without necessarily be more readable, let us know how do you feel. Ideally there should be some kind of autocomplete combobox that takes multiples values, with a predefined list of types to select from, and still the possibility to add any types the user wants. But we could not find such component for now, so we went for the simpler solution.
- The `equivalentProperty`  has been added right after the Field dataType in the table on the left side in the Record Sets tab, as well as in the field details on the right side. We can remove it from the left side table if you feel it is too much and should only be shown in the details

Doing so made us realize some confusing things with the editor example, e.g. with the titanic dataset the RecordSets `genders` and `embarkation_ports` have the type https://schema.org/Enumeration but the checkbox "The RecordSet is an enumeration" is not checked. Wouldn't it make sense to be automatically checked in this case?

We did this during a short hackathon at the https://www.swat4ls.org/ conference (semantic web for life sciences).

It is a beginning of answer to this issue: https://github.com/mlcommons/croissant/issues/739 raised by @benjelloun
 
A lot of people in our community (semantic web for life science research) are interested by the features requested in this issue

We followed the official specs definition for `RecordSet` and `Field`: https://docs.mlcommons.org/croissant/docs/croissant-spec.html#field 

We tested the new features using the docker deployment locally and they work as expected. RecordSet Data types and Field equivalentProperty are properly added to the exported JSON-LD file

It was done with @vemonet 

Also note that in the code for `Field` you use camelcase `equivalentProperty` instead of the usual snake case that is used elsewhere, might want to fix this for overall consistency https://github.com/mlcommons/croissant/blob/main/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/field.py#L71