### PR TITLE
Preserve native sample rate, don't auto-resample to 22050

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/field.py
@@ -96,7 +96,7 @@ def _cast_value(ctx: Context, value: Any, data_type: type | term.URIRef | None):
         else:
             raise ValueError(f"Type {type(value)} is not accepted for an image.")
     elif data_type == DataType.AUDIO_OBJECT:
-        output = deps.librosa.load(io.BytesIO(value))
+        output = deps.librosa.load(io.BytesIO(value), sr=None)
         return output
     elif data_type == DataType.BOUNDING_BOX:  # pytype: disable=wrong-arg-types
         return bounding_box.parse(value)


### PR DESCRIPTION
The default in librosa is sr=22050, which forces resampling, it has to be set explicitly to None to preserve the original sample rate. I doubt this is intentional?

If resampling is desired, the field description should support an explicit target sample rate to enable.