### PR TITLE
Fix ExpectedType of containedIn for FileObject in croissant-spec.md

### DIFF
--- a/docs/croissant-spec.md
+++ b/docs/croissant-spec.md
@@ -647,7 +647,7 @@ In addition, `FileObject` defines the following property:
   </thead>
   <tr>
     <td>containedIn</td>
-    <td><a href="http://schema.org/Text">Text</a></td>
+    <td>Reference</td>
     <td>MANY</td>
     <td>Another <code>FileObject</code> or <code>FileSet</code> that this one is contained in, e.g., in the case of a file extracted from an archive. When this property is present, the <code>contentUrl</code> is evaluated as a relative path within the container object.</td>
   </tr>


### PR DESCRIPTION
In croissant-spec.md, the ExpectedType of `containedIn` is `Text` for `FileObject` and `Reference` for `FileSet`.
https://github.com/mlcommons/croissant/blob/main/docs/croissant-spec.md?plain=1#L648-L653
https://github.com/mlcommons/croissant/blob/main/docs/croissant-spec.md?plain=1#L711-L716

I believe it would be better to set the ExpectedType to `Reference`.