### PR TITLE
Fix signature of `_read_arff_file`

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/read.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/read.py
@@ -83,7 +83,7 @@ def _should_append_line_numbers(fields: tuple[Field, ...]) -> bool:
     return False
 
 
-def _read_arff_file(filepath: str | io.StringIO) -> pd.DataFrame:
+def _read_arff_file(filepath: str | io.StringIO | epath.Path) -> pd.DataFrame:
     """Reads a file in ARFF format and returns it as a pandas DataFrame."""
     if scipy is None:
         raise NotImplementedError(INSTALL_MESSAGE)


### PR DESCRIPTION
Include epath.Path in signature of _read_arff_file