### PR TITLE
in README, link to spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Here is an extremely simple example of the Croissant format, with comments showi
 
 ## Resources
 
+- [Specification](https://docs.mlcommons.org/croissant/docs/croissant-spec.html)
 - [Github Repo](https://github.com/mlcommons/croissant)
   - Specification
   - Examples


### PR DESCRIPTION
This is the same link shown at https://mlcommons.org/working-groups/data/croissant/

Perhaps the spec could also be linked in the first paragraph. 🤷 This is a a start, at least. I was showing a friend the README and he asked where he could find the spec. We went to https://mlcommons.org/croissant and scrolled down to find it.

I'm aware that "Specification" also appears just below under "GitHub Repo". Perhaps this could link to the specs in progress? 🤷 