### PR TITLE
Updated README citation to Neurips paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,19 +182,15 @@ Thank you for supporting Croissant! 🙂
 ## Citation
 
 ```
-@inproceedings{10.1145/3650203.3663326,
-    author = {Akhtar, Mubashara and Benjelloun, Omar and Conforti, Costanza and Gijsbers, Pieter and Giner-Miguelez, Joan and Jain, Nitisha and Kuchnik, Michael and Lhoest, Quentin and Marcenac, Pierre and Maskey, Manil and Mattson, Peter and Oala, Luis and Ruyssen, Pierre and Shinde, Rajat and Simperl, Elena and Thomas, Goeffry and Tykhonov, Slava and Vanschoren, Joaquin and van der Velde, Jos and Vogler, Steffen and Wu, Carole-Jean},
-    title = {Croissant: A Metadata Format for ML-Ready Datasets},
-    year = {2024},
-    isbn = {9798400706110},
-    publisher = {Association for Computing Machinery},
-    address = {New York, NY, USA},
-    url = {https://doi.org/10.1145/3650203.3663326},
-    doi = {10.1145/3650203.3663326},
-    pages = {1–6},
-    numpages = {6},
-    keywords = {ML datasets, discoverability, reproducibility, responsible AI},
-    location = {Santiago, Chile},
-    series = {DEEM '24}
+@inproceedings{NEURIPS2024_9547b09b,
+ author = {Akhtar, Mubashara and Benjelloun, Omar and Conforti, Costanza and Foschini, Luca and Gijsbers, Pieter and Giner-Miguelez, Joan and Goswami, Sujata and Jain, Nitisha and Karamousadakis, Michalis and Krishna, Satyapriya and Kuchnik, Michael and Lesage, Sylvain and Lhoest, Quentin and Marcenac, Pierre and Maskey, Manil and Mattson, Peter and Oala, Luis and Oderinwale, Hamidah and Ruyssen, Pierre and Santos, Tim and Shinde, Rajat and Simperl, Elena and Suresh, Arjun and Thomas, Goeffry and Tykhonov, Slava and Vanschoren, Joaquin and Varma, Susheel and van der Velde, Jos and Vogler, Steffen and Wu, Carole-Jean and Zhang, Luyao},
+ booktitle = {Advances in Neural Information Processing Systems},
+ editor = {A. Globerson and L. Mackey and D. Belgrave and A. Fan and U. Paquet and J. Tomczak and C. Zhang},
+ pages = {82133--82148},
+ publisher = {Curran Associates, Inc.},
+ title = {Croissant: A Metadata Format for ML-Ready Datasets},
+ url = {https://proceedings.neurips.cc/paper_files/paper/2024/file/9547b09b722f2948ff3ddb5d86002bc0-Paper-Datasets_and_Benchmarks_Track.pdf},
+ volume = {37},
+ year = {2024}
 }
 ```


### PR DESCRIPTION
Since the Neurips paper is a more current extension of Croissant, it should be cited instead of the DEEM workshop paper.