### PR TITLE
Fix conformsTo

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata.py
@@ -370,6 +370,8 @@ class Metadata(Node):
             conforms_to = (
                 self.conforms_to[0] if len(self.conforms_to) == 1 else self.conforms_to
             )
+        elif self.ctx.conforms_to:
+            conforms_to = self.ctx.conforms_to.to_json()
         else:
             conforms_to = None
         jsonld["conformsTo"] = conforms_to

--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/metadata.py
@@ -366,14 +366,13 @@ class Metadata(Node):
         jsonld = super().to_json()
         jsonld.pop("@id", None)
         jsonld["@context"] = context
+        conforms_to: str | list[str] | None = None
         if self.conforms_to:
             conforms_to = (
                 self.conforms_to[0] if len(self.conforms_to) == 1 else self.conforms_to
             )
         elif self.ctx.conforms_to:
             conforms_to = self.ctx.conforms_to.to_json()
-        else:
-            conforms_to = None
         jsonld["conformsTo"] = conforms_to
         if self.ctx.is_live_dataset:
             jsonld["isLiveDataset"] = self.ctx.is_live_dataset


### PR DESCRIPTION
When no conformsTo is specified (as for example when creating metadata from a notebook) then use the conformsTo from Context to populate that field.

This also fixes the notebook errors introduced in https://github.com/mlcommons/croissant/pull/892