### PR TITLE
Source can also specify `format`.

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/source.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/nodes/source.py
@@ -185,6 +185,12 @@ class Source(Node):
         url=constants.SCHEMA_ORG_DISTRIBUTION,
         versions=[CroissantVersion.V_0_8],
     )
+    extract: Extract = mlc_dataclasses.jsonld_field(
+        default_factory=Extract,
+        description="",
+        input_types=[Extract],
+        url=constants.ML_COMMONS_EXTRACT,
+    )
     field: str | None = mlc_dataclasses.jsonld_field(
         default=None,
         description="",
@@ -207,11 +213,10 @@ class Source(Node):
         to_jsonld=formatted_uuid_to_json,
         url=constants.ML_COMMONS_FILE_SET,
     )
-    extract: Extract = mlc_dataclasses.jsonld_field(
-        default_factory=Extract,
-        description="",
-        input_types=[Extract],
-        url=constants.ML_COMMONS_EXTRACT,
+    format: str | None = mlc_dataclasses.jsonld_field(
+        default=None,
+        input_types=[SDO.Text],
+        url=constants.ML_COMMONS_FORMAT,
     )
     transforms: list[Transform] = mlc_dataclasses.jsonld_field(
         cardinality="MANY",


### PR DESCRIPTION
This follows the specs: https://docs.mlcommons.org/croissant/docs/croissant-spec.html#boundingbox