### PR TITLE
introduction.ipynb: use idiomatic python

### DIFF
--- a/python/mlcroissant/recipes/introduction.ipynb
+++ b/python/mlcroissant/recipes/introduction.ipynb
@@ -244,11 +244,10 @@
         "import json\n",
         "\n",
         "with open(\"croissant.json\", \"w\") as f:\n",
-        "  content = metadata.to_json()\n",
-        "  content = json.dumps(content, indent=2)\n",
-        "  print(content)\n",
-        "  f.write(content)\n",
-        "  f.write(\"\\n\")  # Terminate file with newline"
+        "    content = metadata.to_json()\n",
+        "    content = json.dumps(content, indent=2)\n",
+        "    print(content)\n",
+        "    f.write(content)\n"
       ]
     },
     {
@@ -290,10 +289,8 @@
       "source": [
         "records = dataset.records(record_set=\"jsonl\")\n",
         "\n",
-        "for i, record in enumerate(records):\n",
-        "  print(record)\n",
-        "  if i > 10:\n",
-        "    break"
+        "for i, record in zip(range(12), records):\n",
+        "    print(record)"
       ]
     },
     {


### PR DESCRIPTION
Some small changes to the introduction.ipynb to make the python examples more idiomatic:

- use consistent 4-space indents
- remove unnecessary terminate file with newline specifically called out in comment
- use range(12) instead of enumerate, if i > 10: break to produce 12 rows