### PR TITLE
Fix typo in RDF: `rdfs:label "ContexExtractionEnumeration"` -> `rdfs:label "ContentExtractionEnumeration"`

### DIFF
--- a/docs/croissant.ttl
+++ b/docs/croissant.ttl
@@ -55,7 +55,7 @@ croissant:Transform a rdf:Class ;
 # Enumerations
 
 croissant:ContentExtractionEnumeration a rdf:Class ;
-  rdfs:label "ContexExtractionEnumeration" ;
+  rdfs:label "ContentExtractionEnumeration" ;
   rdfs:comment "Specifies which content to extract from a file. One of \"all\", \"lines\", or \"lineNumbers\"." ;
   rdfs:subClassOf schema:Enumeration .
 


### PR DESCRIPTION
The class is `croissant:ContentExtractionEnumeration`, updating the RDF label to match: 

```
croissant:ContentExtractionEnumeration a rdf:Class ;
  rdfs:label "ContentExtractionEnumeration" ;
```