### PR TITLE
Added support for png, jpg and tiff file formats

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/core/constants.py
+++ b/python/mlcroissant/mlcroissant/_src/core/constants.py
@@ -242,7 +242,8 @@ class EncodingFormat:
     TSV = "text/tab-separated-values"
     TAR = "application/x-tar"
     ZIP = "application/zip"
-
+    PNG = "image/png"
+    TIF = "image/tiff"
 
 class DataType:
     """Data types supported by Croissant."""

--- a/python/mlcroissant/mlcroissant/_src/operation_graph/operations/read.py
+++ b/python/mlcroissant/mlcroissant/_src/operation_graph/operations/read.py
@@ -11,6 +11,7 @@ from etils import epath
 import numpy as np
 import pandas as pd
 
+from PIL import Image
 from mlcroissant._src.core.constants import EncodingFormat
 from mlcroissant._src.core.git import download_git_lfs_file
 from mlcroissant._src.core.git import is_git_lfs_file
@@ -181,7 +182,6 @@ class Read(Operation):
                         })
                 elif (
                     encoding_format == EncodingFormat.MP3
-                    or encoding_format == EncodingFormat.JPG
                 ):
                     sampling_rate = _get_sampling_rate(self.node, self.fields)
                     if sampling_rate:
@@ -190,6 +190,11 @@ class Read(Operation):
                         out = deps.librosa.load(file)
                     return pd.DataFrame({
                         FileProperty.content: [out],
+                    })
+                elif encoding_format in {EncodingFormat.TIF, EncodingFormat.JPG, EncodingFormat.PNG}:
+                    img = Image.open(file).convert("RGB")
+                    return pd.DataFrame({
+                        FileProperty.content: [img]
                     })
             raise ValueError(
                 f"None of the provided encoding formats: {encoding_format} for file"


### PR DESCRIPTION
Me and my team would like to use Croissant for Earth Observation datasets. This PR introduces support for PNG and TIFF image formats in croissant. Additionally, it modifies the way JPEG files are processed to better align with the requirements of Earth Observation tasks. 