### PR TITLE
Eclair additions

### DIFF
--- a/eclair/README.md
+++ b/eclair/README.md
@@ -57,8 +57,10 @@ Most importantly, Eclair aims to create an **open, global ecosystem** of data so
 3. **datasets-preview-url**: Get a download URL for a dataset preview
 4. **serve-croissant**: Get the Croissant metadata for a given dataset
 5. **validate-croissant**: Validate a Croissant metadata file
-6. **help**: Get instructions to use the Eclair tools
-7. **ping**: Test that your Eclair server is working
+6. **builder-context**: Guidance for LLM/agents on Croissant + TFDS/PyTorch best practices
+7. **pytorch-scaffold**: Generate a ready-to-run PyTorch Dataset scaffold from a Croissant URL
+8. **help**: Get instructions to use the Eclair tools
+9. **ping**: Test that your Eclair server is working
 
 
 ## Installation
@@ -89,6 +91,21 @@ pip install -e .[dev]
 Alternatively, use the provided quickstart script to install and start the server:
 ```bash
 ./start.sh
+```
+
+### Using the Eclair MCP without installation
+
+You can plug in the following config into your MCP client (e.g. Cursor, Zed, Windsurf, etc) to use a hosted test-version of the MCP directly:
+
+```
+{
+  "mcpServers": {
+    "croissant-mcp": {
+      "url": "http://35.87.210.99:8000/sse",
+      "transport": "sse"
+    }
+  }
+}
 ```
 
 # Running the Server

--- a/eclair/README.md
+++ b/eclair/README.md
@@ -996,5 +996,6 @@ pip install -e .
 * Omar Benjelloun (Google Deepmind)
 * Jon Lebenshold (Jetty)
 * Natasha Noy (Google)
+* Luis Oala
 
 Thank you for supporting Eclair! 🙂

--- a/eclair/src/eclair/server/context/builder_context.md
+++ b/eclair/src/eclair/server/context/builder_context.md
@@ -8,6 +8,11 @@ This context helps agents guide users to build datasets using MLCommons Croissan
 - TFDS Croissant builder recipe: `https://github.com/mlcommons/croissant/blob/main/python/mlcroissant/recipes/tfds_croissant_builder.ipynb`
 - Python library: `https://github.com/mlcommons/croissant/tree/main/python/mlcroissant`
 
+Hugging Face tip: use the Croissant JSON-LD endpoint
+
+- Page URL: `https://huggingface.co/datasets/<org-or-user>/<dataset>`
+- JSON-LD: `https://huggingface.co/api/datasets/<org-or-user>/<dataset>/croissant`
+
 ## Core Ideas
 
 1. Use `mlcroissant.Dataset(jsonld=<url_or_dict>)` to load Croissant metadata and access records via `dataset.records(record_set, filters=...)`.

--- a/eclair/src/eclair/server/context/builder_context.md
+++ b/eclair/src/eclair/server/context/builder_context.md
@@ -1,0 +1,36 @@
+# Croissant Builder Context for LLM/Agents
+
+This context helps agents guide users to build datasets using MLCommons Croissant with TFDS and PyTorch.
+
+## Key References
+
+- Croissant spec: `http://mlcommons.org/croissant/1.0`
+- TFDS Croissant builder recipe: `https://github.com/mlcommons/croissant/blob/main/python/mlcroissant/recipes/tfds_croissant_builder.ipynb`
+- Python library: `https://github.com/mlcommons/croissant/tree/main/python/mlcroissant`
+
+## Core Ideas
+
+1. Use `mlcroissant.Dataset(jsonld=<url_or_dict>)` to load Croissant metadata and access records via `dataset.records(record_set, filters=...)`.
+2. Choose a `RecordSet` by its `@id`. Inspect metadata to find `sc:RecordSet` nodes and their fields.
+3. Apply filters for splits (e.g., `{ "split": "train" }`), adjusting the field ID to match metadata (`data/split` vs `split`).
+4. For PyTorch, wrap Croissant access in `torch.utils.data.Dataset` and implement `__len__`/`__getitem__`.
+
+## Minimal PyTorch Pattern
+
+```python
+from mlcroissant import Dataset as CroissantDataset
+
+cds = CroissantDataset(jsonld="<CROISSANT_URL>")
+examples = list(cds.records("<RECORD_SET_ID>", filters={"split": "train"}))
+# map examples to tensors in a custom Dataset
+```
+
+## TFDS Interop
+
+The TFDS recipe illustrates mapping Croissant records to TFDS features. Use the same mapping logic to produce tensors for PyTorch.
+
+## Tips
+
+- Some fields are URIs to files (images, audio). Load lazily in `__getitem__`.
+- Large datasets: prefer streaming (`for ex in cds.records(...)`) instead of materializing.
+- Validate metadata with the `validate-croissant` tool when troubleshooting.

--- a/eclair/src/eclair/server/context/help.md
+++ b/eclair/src/eclair/server/context/help.md
@@ -11,6 +11,8 @@ The Eclair MCP Server provides the following tools for dataset discovery and man
 - `serve-croissant` - Get the Croissant dataset metadata
 - `validate-croissant` - Validate Croissant metadata
 - `download-dataset` - Get download information for a dataset
+- `builder-context` - Guidance for agents building datasets with Croissant/TFDS/PyTorch
+- `pytorch-scaffold` - Generate a PyTorch Dataset scaffold from a Croissant URL
 - `help` - Get this help information
 - `ping` - Test server connectivity
 
@@ -82,3 +84,24 @@ To get information about downloading a complete dataset:
 
 **Tool:** `download-dataset`
 **Parameters:** `collection` (string), `dataset` (string)
+
+## 6. Builder Context (for LLM/Agents)
+
+High-signal guidance to help agents assist users in constructing datasets:
+
+**Tool:** `builder-context`
+
+**Parameters:** none
+
+## 7. PyTorch Scaffold Generator
+
+Generate a ready-to-run PyTorch `Dataset` class using a Croissant URL.
+
+**Tool:** `pytorch-scaffold`
+
+**Parameters:**
+
+- `croissant_url` (string) - URL to Croissant JSON-LD
+- `record_set` (string, optional) - RecordSet `@id`
+- `x_fields` (list[string], optional) - Input field IDs
+- `y_field` (string, optional) - Target field ID

--- a/eclair/src/eclair/server/server.py
+++ b/eclair/src/eclair/server/server.py
@@ -19,6 +19,8 @@ from .tools import (
     search_datasets,
     get_help,
     get_dataset_metadata,
+    get_builder_context,
+    generate_pytorch_scaffold,
     ping,
     cleanup
 )
@@ -90,6 +92,30 @@ class EclairServer:
         async def ping_tool() -> str:
             """Simple ping test to verify the Eclair server is working."""
             return await ping()
+
+        @self.mcp.tool(
+            "builder-context",
+            description="Guidance for LLM/agents on building datasets with Croissant/TFDS/PyTorch",
+        )
+        async def builder_context_tool() -> str:
+            return await get_builder_context()
+
+        @self.mcp.tool(
+            "pytorch-scaffold",
+            description="Generate a PyTorch Dataset scaffold from a Croissant URL",
+        )
+        async def pytorch_scaffold_tool(
+            croissant_url: str,
+            record_set: str | None = None,
+            x_fields: list[str] | None = None,
+            y_field: str | None = None,
+        ) -> dict[str, Any]:
+            return await generate_pytorch_scaffold(
+                croissant_url=croissant_url,
+                record_set=record_set,
+                x_fields=x_fields,
+                y_field=y_field,
+            )
 
         # Debug prompt
         @self.mcp.prompt()

--- a/eclair/src/eclair/server/tools.py
+++ b/eclair/src/eclair/server/tools.py
@@ -233,14 +233,14 @@ from mlcroissant import Dataset as CroissantDataset
 
 
 class CroissantTorchDataset(Dataset):
-    """PyTorch Dataset backed by a Croissant metadata description.
+    '''PyTorch Dataset backed by a Croissant metadata description.
 
     - jsonld: Croissant JSON-LD URL or dict
     - record_set: ID of the RecordSet to iterate over (matches @id in metadata)
     - split: optional split value to filter (e.g., "train", "validation", "test")
     - x_fields: list of field IDs to form the input tensor or structure
     - y_field: field ID for the label/target
-    """
+    '''
 
     def __init__(
         self,
@@ -269,7 +269,7 @@ class CroissantTorchDataset(Dataset):
         if self.split:
             # Common split field IDs include "data/split" or "split"; update if needed
             # Adjust the key here to match your metadata field ID
-            filters = {"split": self.split}
+            filters = {{"split": self.split}}
 
         self._examples: List[Dict[str, Any]] = list(self._ds.records(self.record_set, filters=filters))
 


### PR DESCRIPTION
- add a pytorch scaffold tool using the tfds sample to help user serve croissant ds as a pt ds object
- add a live hosted test mcp for quick plug and play exploration of the mcp