### PR TITLE
Fix cyclic dependencies in operation graph for field.references

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/structure_graph/graph.py
+++ b/python/mlcroissant/mlcroissant/_src/structure_graph/graph.py
@@ -63,13 +63,17 @@ def from_nodes_to_graph(metadata) -> nx.MultiDiGraph:
     for record_set in metadata.record_sets:
         for field in record_set.fields:
             _add_edge(graph, uuid_to_node, record_set.uuid, field)
-            for origin in [field.source, field.references]:
-                if origin:
-                    _add_edge(graph, uuid_to_node, origin.uuid, record_set)
+            if field.source:
+                _add_edge(graph, uuid_to_node, field.source.uuid, record_set)
+            # Dependency on references: Referenced Field -> Referencing Field
+            if field.references:
+                _add_edge(graph, uuid_to_node, field.references.uuid, field)
             for sub_field in field.sub_fields:
-                for origin in [sub_field.source, sub_field.references]:
-                    if origin:
-                        _add_edge(graph, uuid_to_node, origin.uuid, record_set)
+                if sub_field.source:
+                    _add_edge(graph, uuid_to_node, sub_field.source.uuid, record_set)
+                # Dependency on references: Referenced Field -> Referencing Field
+                if sub_field.references:
+                    _add_edge(graph, uuid_to_node, sub_field.references.uuid, sub_field)
     # `Metadata` are used as the entry node.
     _add_node_as_entry_node(graph, metadata)
     return graph


### PR DESCRIPTION
Original [PR](https://github.com/mlcommons/croissant/pull/948).
Renamed the branch from "issue#904" -> "issue-904" to prevent errors for `pip install`.
Also fixed backward compatibility issues with graph constructions for Croissant metadata using version 0.8 and 1.0, where `field.references` can lead to `FileObject` or `FileSet` (similar to `field.source`).