### PR TITLE
bump media type to 1.1 to match "conformsTo"

### DIFF
--- a/docs/croissant-spec-draft.md
+++ b/docs/croissant-spec-draft.md
@@ -246,7 +246,7 @@ Note that while the Croissant specification is versioned, the Croissant namespac
 The media type (content type or MIME type) for Croissant includes a JSON-LD [profile](https://www.w3.org/TR/json-ld/#application-ld-json) to distinguish it from other JSON-LD documents:
 
 ```
-application/ld+json; profile="http://mlcommons.org/croissant/1.0"
+application/ld+json; profile="http://mlcommons.org/croissant/1.1"
 ```
 
 ### ID and Reference Mechanism


### PR DESCRIPTION
@benjelloun had a brief conversation about the media type section the other day when talking about the differences between the 1.0 and 1.1 specs. I forget what I said then but I think we should bump the version to 1.1 to match what we have in "conformsTo".

I added the media type section. See the following PR and issue:

- #801
- #792 