### PR TITLE
Update authors list of Croissant 1.1 specification

### DIFF
--- a/docs/croissant-spec-1.1.md
+++ b/docs/croissant-spec-1.1.md
@@ -19,9 +19,6 @@ Authors:
 - Joan Giner-Miguelez (Barcelona Supercomputing Center),
 - Mubashara Akthar (ETH Zurich & ETH AI Center),
 - Nitisha Jain (Independent),
-- Joan Giner-Miguelez (Barcelona Supercomputing Center),
-- Mubashara Akthar (ETH Zurich & ETH AI Center),
-- Nitisha Jain (Independent),
 - Joaquin Vanschoren (OpenML),
 - Luis Oala (Dotphoton),
 - Pascal Heus (CODATA)


### PR DESCRIPTION
This PR updates the authors list for the Croissant 1.1 spec, following the W3C TAG group guidelines at https://www.w3.org/2001/tag/contributor, which are often followed by W3C specifications.

