### PR TITLE
First version of consolidated documentation

### DIFF
--- a/gen_pages.py
+++ b/gen_pages.py
@@ -1,0 +1,34 @@
+# Generates MkDocs pages from various parts of the repo.
+# MKDocs expects all documentation files to be in the 'docs/' directory.
+# This script this called when building mkdocs to copy documentation from 
+# other parts of the repo to a virtual 'docs/' directory.
+from pathlib import Path
+
+import mkdocs_gen_files
+
+# Get the root directory of the repo
+root = Path(__file__).parent
+
+# 1. Copy the Root README to 'index.md' AND fix image paths
+with open(root / "README.md", "r", encoding="utf-8") as f:
+    content = f.read()
+
+content = content.replace("/docs/images/", "images/")
+content = content.replace("docs/images/", "images/")
+
+with mkdocs_gen_files.open("index.md", "w", encoding="utf-8") as dest:
+    dest.write(content)
+
+# 2. List of folders you want to include from the root
+folders_to_include = ["python", "eclair", "editor", "health", "croissant-rdf"]
+
+for folder in folders_to_include:
+    # Recursively copy all files from these folders
+    for path in sorted((root / folder).rglob("*")):
+        if path.is_file():
+            # Calculate the relative path (e.g., python/mlcroissant/README.md)
+            rel_path = path.relative_to(root)
+            # Write it to the virtual docs directory
+            with open(path, "rb") as src:
+                with mkdocs_gen_files.open(rel_path, "wb") as dest:
+                    dest.write(src.read())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,112 @@
+site_name: Croissant
+site_description: Documentation for the MLCommons Croissant metadata format and ecosystem.
+site_url: https://docs.mlcommons.org/croissant/
+repo_url: https://github.com/mlcommons/croissant
+repo_name: mlcommons/croissant
+
+# Theme configuration
+theme:
+  name: material
+  logo: https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/1f950.svg
+  favicon: https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/1f950.svg
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+  palette:
+    - scheme: default
+      primary: light-green
+      accent: green
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      primary: light-green
+      accent: green
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+plugins:
+  - search
+  # This plugin runs the script to pull in outside files
+  - gen-files:
+      scripts:
+        - gen_pages.py
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [python, src]
+
+# Navigation Structure
+nav:
+  # 'README.md' was copied to 'index.md' by our script
+  - Croissant:
+      - Overview: index.md
+      - Specification:
+          # These files are physically in docs/, so we REMOVE the 'docs/' prefix
+          - 'Croissant v1.1': croissant-spec-1.1.md
+          - 'Croissant v1.0': croissant-spec-1.0.md
+      - Extensions:
+          - 'Responsible AI (RAI)': croissant-rai-spec.md
+
+  - Library:
+      - 'Python Package': python/mlcroissant/README.md
+ 
+  - Tools:
+      - 'Croissant Editor': editor/README.md
+      - 'Health Monitor': health/README.md
+      - 'Online Validator': health/croissant-validator-neurips/README.md
+      - 'Croissant RDF': croissant-rdf/README.md
+
+  - Eclair:
+      - Getting Started:
+          - Welcome: eclair/docs/index.md
+          - Installation and Setup: eclair/docs/getting-started/installation.md
+          - Running the Server: eclair/docs/getting-started/running-server.md
+      - Usage Guides:
+          - Overview: eclair/docs/usage/overview.md
+          - AI Agents:
+              - Gemini CLI: eclair/docs/usage/ai-agents/gemini-cli.md
+              - Claude Code: eclair/docs/usage/ai-agents/claude-code.md
+          - IDE Integration:
+              - VS Code + Gemini Code Assist: eclair/docs/usage/ide/vscode-gemini.md
+              - VS Code + Copilot: eclair/docs/usage/ide/vscode-copilot.md
+          - Python API: eclair/docs/usage/python-api.md
+          - Command Line Interface: eclair/docs/usage/cli.md
+      - API Reference:
+          - Available Tools: eclair/docs/api/tools.md
+          - Python Client: eclair/docs/api/python-client.md
+      - Development:
+          - Getting Started: eclair/docs/development/index.md
+
+# Markdown Extensions
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+# Optional: Exclude build artifacts from scanning
+exclude_docs: |
+  *.py
+  __pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs>=1.5.0
+mkdocs-material>=9.4.0
+mkdocstrings[python]>=0.23.0
+pymdown-extensions>=10.3
+mkdocs-gen-files


### PR DESCRIPTION
This PR creates a documentation website that consolidates the different pieces of documentation into a single website,  based on MkDocs. 

<img width="1523" height="1012" alt="Screenshot 2026-02-04 at 19 13 27" src="https://github.com/user-attachments/assets/85e1c583-b5bd-45a4-bdd4-f2e4a7b32ec8" />

Next steps:
- [ ] Make any changes to the website structure in the .yml file.
- [ ] After merging, set up a GitHub action that automatically rebuilds the website with every repo update, and hosts it on GitHub Pages
- [ ] Ask mlcommons to reconfigure GitHub so that https://mlcommons.github.io/croissant points to the croissant GitHub Pages
- [ ] Add a clear link/button from https://mlcommons.org/working-groups/data/croissant/ to this documentation

After that, incremental updates can be made, for instance:
* Adding additional extensions (bio, geo)
* Adding example datasets described in Croissant
* Adding a page with example use cases
* Adding an API reference for the mlcroissant library