### PR TITLE
Fix unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install library
-      run: sudo apt-get install -y libgraphviz-dev
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3-dev graphviz libgraphviz-dev pkg-config
 
     - run: pip install ipython ipykernel nbconvert
 

--- a/python/mlcroissant/recipes/bounding-boxes.ipynb
+++ b/python/mlcroissant/recipes/bounding-boxes.ipynb
@@ -28,8 +28,7 @@
    "outputs": [],
    "source": [
     "# Install mlcroissant from the source\n",
-    "!apt-get install -y python3-dev graphviz libgraphviz-dev pkg-config\n",
-    "!pip install \"git+https://github.com/${GITHUB_REPOSITORY:-mlcommons/croissant}.git@${GITHUB_HEAD_REF:-main}#subdirectory=python/mlcroissant&egg=mlcroissant[dev]\"\n",
+    "!pip install \"mlcroissant[dev] @ git+https://github.com/${GITHUB_REPOSITORY:-mlcommons/croissant}.git@${GITHUB_HEAD_REF:-main}#subdirectory=python/mlcroissant\"\n",
     "\n",
     "# Needed imports in the notebook:\n",
     "import io\n",

--- a/python/mlcroissant/recipes/introduction.ipynb
+++ b/python/mlcroissant/recipes/introduction.ipynb
@@ -37,8 +37,7 @@
       "outputs": [],
       "source": [
         "# Install mlcroissant from the source\n",
-        "!apt-get install -y python3-dev graphviz libgraphviz-dev pkg-config\n",
-        "!pip install \"git+https://github.com/${GITHUB_REPOSITORY:-mlcommons/croissant}.git@${GITHUB_HEAD_REF:-main}#subdirectory=python/mlcroissant&egg=mlcroissant[dev]\""
+        "!pip install \"mlcroissant[dev] @ git+https://github.com/${GITHUB_REPOSITORY:-mlcommons/croissant}.git@${GITHUB_HEAD_REF:-main}#subdirectory=python/mlcroissant\""
       ]
     },
     {


### PR DESCRIPTION
Starting from pip 23.1 the `#egg=pkg_name` syntax used in our notebooks got deprecated.
This PR updates the syntax and moves the common system dependencies to the github action workflow.