### PR TITLE
fix: Update visualize workflow to push to gh-pages

### DIFF
--- a/.github/workflows/visualize.yml
+++ b/.github/workflows/visualize.yml
@@ -46,3 +46,5 @@ jobs:
       with:
         commit_message: "docs: Update dataset visualizations [skip ci]"
         file_pattern: 'datasets/**/index.html datasets/index.html datasets/static/gallery.min.js datasets/static/gallery.min.css'
+        branch: gh-pages
+        create_branch: true


### PR DESCRIPTION
This is a fix for: https://github.com/mlcommons/croissant/actions/runs/25005738253/job/73227866719