### PR TITLE
Fix custom JSON-LD type-checking compatibility for Python 3.14 upgrade

### DIFF
--- a/python/mlcroissant/mlcroissant/_src/core/dataclasses.py
+++ b/python/mlcroissant/mlcroissant/_src/core/dataclasses.py
@@ -192,7 +192,6 @@ def jsonld_fields(cls_or_instance) -> Iterator[JsonldField]:
                 continue
         metadata = cast(Metadata, field.metadata)
         if metadata:
-            _check_types(cls_or_instance, field, metadata)
             yield JsonldField(
                 default=field.default,
                 default_factory=field.default_factory,
@@ -206,7 +205,12 @@ def jsonld_fields(cls_or_instance) -> Iterator[JsonldField]:
 )  # pytype: disable=not-supported-yet
 def dataclass(cls):
     """Overloads the built-in dataclass with JsonldFields instead of Fields."""
-    return dataclasses.dataclass(eq=False, repr=False)(cls)
+    cls = dataclasses.dataclass(eq=False, repr=False)(cls)
+    for field in dataclasses.fields(cls):
+        metadata = cast(Metadata, field.metadata)
+        if metadata:
+            _check_types(cls, field, metadata)
+    return cls
 
 
 def _check_types(cls_or_instance, field: dataclasses.Field, metadata: Metadata) -> None:
@@ -243,7 +247,8 @@ def _check_types(cls_or_instance, field: dataclasses.Field, metadata: Metadata) 
     if cast_fn:
         # The field defines cast_fn: we check that Python type == cast_fn output type.
         signature = inspect.signature(cast_fn)
-        name = f"{field_name} with cast_fn={cast_fn.__name__}"
+        cast_fn_name = getattr(cast_fn, "__name__", cast_fn)
+        name = f"{field_name} with cast_fn={cast_fn_name}"
         _types_are_equal(name, field.type, signature.return_annotation)
     else:
         # Python type == expected JSON-LD type.

--- a/python/mlcroissant/mlcroissant/_src/core/dataclasses_test.py
+++ b/python/mlcroissant/mlcroissant/_src/core/dataclasses_test.py
@@ -77,57 +77,54 @@ def test_jsonld_fields():
     assert fields[0].name == "field2"
 
 
-@pytest.mark.parametrize(
-    "accessor",
-    [
-        # Access class
-        lambda cls: cls,
-        # Access instance of class
-        lambda cls: cls(),
-    ],
-)
-def test_types_of_fields(accessor):
-    @mlc_dataclasses.dataclass
-    class SubNode(Node):
-        field: int | None = mlc_dataclasses.jsonld_field(
-            default=None,
-            input_types=[SDO.Text],  # this is incompatible with `int`
-        )
+def test_types_of_fields():
+    with pytest.raises(
+        TypeError,
+        match='Field "IncompatibleIntAndTextNode.field" should have type',
+    ):
+        @mlc_dataclasses.dataclass
+        class IncompatibleIntAndTextNode(Node):
+            field: int | None = mlc_dataclasses.jsonld_field(
+                default=None,
+                input_types=[SDO.Text],  # this is incompatible with `int`
+            )
 
-    with pytest.raises(TypeError, match='Field "SubNode.field" should have type'):
-        list(mlc_dataclasses.jsonld_fields(accessor(SubNode)))
+    with pytest.raises(
+        TypeError,
+        match='Field "IncompatibleDefaultNoneNode.field" should have type',
+    ):
+        @mlc_dataclasses.dataclass
+        class IncompatibleDefaultNoneNode(Node):
+            field: int = mlc_dataclasses.jsonld_field(
+                default=None,  # this is incompatible with `int` (expect int | None)
+                input_types=[SDO.Integer],
+            )
 
-    @mlc_dataclasses.dataclass
-    class SubNode(Node):
-        field: int = mlc_dataclasses.jsonld_field(
-            default=None,  # this is incompatible with `int` (expect int | None)
-            input_types=[SDO.Integer],
-        )
-
-    with pytest.raises(TypeError, match='Field "SubNode.field" should have type'):
-        list(mlc_dataclasses.jsonld_fields(accessor(SubNode)))
-
-    @mlc_dataclasses.dataclass
-    class SubNode(Node):
-        field: str = mlc_dataclasses.jsonld_field(
-            default_factory=Node,  # this is incompatible with str
-            input_types=[Node],
-        )
-
-    with pytest.raises(TypeError, match='Field "SubNode.field" should have type'):
-        list(mlc_dataclasses.jsonld_fields(accessor(SubNode)))
+    with pytest.raises(
+        TypeError,
+        match='Field "IncompatibleDefaultFactoryNode.field" should have type',
+    ):
+        @mlc_dataclasses.dataclass
+        class IncompatibleDefaultFactoryNode(Node):
+            field: str = mlc_dataclasses.jsonld_field(
+                default_factory=Node,  # this is incompatible with str
+                input_types=[Node],
+            )
 
     def cast_fn(value: Node) -> int:  # int is incompatible with Node
         del value
         return 0
 
-    @mlc_dataclasses.dataclass
-    class SubNode(Node):
-        field: Node = mlc_dataclasses.jsonld_field(
-            cast_fn=cast_fn,
-            default_factory=Node,
-            input_types=[Node],
-        )
-
-    with pytest.raises(TypeError, match='Field "SubNode.field" .* should have type'):
-        list(mlc_dataclasses.jsonld_fields(accessor(SubNode)))
+    with pytest.raises(
+        TypeError,
+        match=(
+            'Field "IncompatibleCastFunctionReturnNode.field" .* should have type'
+        ),
+    ):
+        @mlc_dataclasses.dataclass
+        class IncompatibleCastFunctionReturnNode(Node):
+            field: Node = mlc_dataclasses.jsonld_field(
+                cast_fn=cast_fn,
+                default_factory=Node,
+                input_types=[Node],
+            )

--- a/python/mlcroissant/mlcroissant/_src/core/dataclasses_test.py
+++ b/python/mlcroissant/mlcroissant/_src/core/dataclasses_test.py
@@ -82,6 +82,7 @@ def test_types_of_fields():
         TypeError,
         match='Field "IncompatibleIntAndTextNode.field" should have type',
     ):
+
         @mlc_dataclasses.dataclass
         class IncompatibleIntAndTextNode(Node):
             field: int | None = mlc_dataclasses.jsonld_field(
@@ -93,6 +94,7 @@ def test_types_of_fields():
         TypeError,
         match='Field "IncompatibleDefaultNoneNode.field" should have type',
     ):
+
         @mlc_dataclasses.dataclass
         class IncompatibleDefaultNoneNode(Node):
             field: int = mlc_dataclasses.jsonld_field(
@@ -104,6 +106,7 @@ def test_types_of_fields():
         TypeError,
         match='Field "IncompatibleDefaultFactoryNode.field" should have type',
     ):
+
         @mlc_dataclasses.dataclass
         class IncompatibleDefaultFactoryNode(Node):
             field: str = mlc_dataclasses.jsonld_field(
@@ -117,10 +120,9 @@ def test_types_of_fields():
 
     with pytest.raises(
         TypeError,
-        match=(
-            'Field "IncompatibleCastFunctionReturnNode.field" .* should have type'
-        ),
+        match='Field "IncompatibleCastFunctionReturnNode.field" .* should have type',
     ):
+
         @mlc_dataclasses.dataclass
         class IncompatibleCastFunctionReturnNode(Node):
             field: Node = mlc_dataclasses.jsonld_field(


### PR DESCRIPTION
### Motivation
This PR prepares Python 3.14 upgrade by moving custom JSON-LD type-checking validation from runtime (inside the jsonld_fields generator) to class definition/import time (inside the @mlc_dataclasses.dataclass decorator).

### Background Context
Python 3.14 introduces deferred/lazy evaluation of type annotations ([PEP 649](https://peps.python.org/pep-0649/)).

In mlcroissant, type-checking validation was previously executed dynamically at runtime when traversing fields. If a downstream user or test suite dynamically mocks a type globally (for instance, patching datetime.datetime to return a custom subclass like MockDatetime during unit tests), then resolving type annotations dynamically at runtime will point to the mocked class MockDatetime, while the static class fields established during module import time still point to the original datetime.datetime. This mismatch would result in a strict type-checking TypeError at runtime. (e.g. TypeError: Field "Metadata.date_created" should have type MockDatetime | None. Got datetime.datetime | None)

Moving this check to class definition time ensures all type annotations are evaluated immediately when the module is imported/loaded, making the library robust against runtime type mocking/patching (e.g., for testing components like croissant_pipelines_test internally) and enforcing a clean, fail-fast architecture for static class definitions.
